### PR TITLE
Add xml schema validation info

### DIFF
--- a/data/ATA71.xml
+++ b/data/ATA71.xml
@@ -7,7 +7,7 @@
 <dmodule
   xmlns="http://www.s1000d.org/S1000DIssue6.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.s1000d.org/S1000DIssue6.0 S1000D_6.0_Schema.xsd">
+  xsi:schemaLocation="http://www.s1000d.org/S1000DIssue6.0 schemas/S1000D_6.0_Schema.xsd">
 
   <identAndStatusSection>
     <dmAddress>


### PR DESCRIPTION
## Summary by Sourcery

Updates the XML schema location to reference a local copy within the `schemas/` directory. This change improves portability and reduces external dependencies by referencing a local schema file.