### PR TITLE
Add mission classification sections to EDR documents

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,7 @@
+{
+  "tasks": {
+    "test": "print here my project",
+    "build": "incapsulate into my projects",
+    "launch": "publish my project"
+  }
+}

--- a/docs/GP-AM/EDR/00/GP-AM-EDR-00-001.md
+++ b/docs/GP-AM/EDR/00/GP-AM-EDR-00-001.md
@@ -15,7 +15,8 @@
 5. [Key Performance Parameters](#5-key-performance-parameters)
 6. [Operational Envelope](#6-operational-envelope)
 7. [Sustainability Features](#7-sustainability-features)
-8. [References](#8-references)
+8. [Mission Classification](#8-mission-classification)
+9. [References](#9-references)
 
 ## 1. Introduction
 ### 1.1 Purpose
@@ -165,7 +166,24 @@ The AEHCS integrates multiple energy harvesting technologies:
 - Optimized aerodynamic surfaces to minimize airframe noise
 - Low-noise approach and departure procedures
 
-## 8. References
+## 8. Mission Classification
+### 8.1 M1: Suborbital
+- Description: Missions that involve suborbital flights, typically for research, tourism, or short-duration space missions.
+- Key Features: High-altitude flight capabilities, rapid ascent and descent, minimal time in space.
+
+### 8.2 M2: Orbital
+- Description: Missions that involve placing payloads or crew into orbit around Earth.
+- Key Features: Sustained orbital flight, re-entry capabilities, long-duration space missions.
+
+### 8.3 M3: Vuelo comercial
+- Description: Commercial flights for passenger and cargo transport.
+- Key Features: High efficiency, low emissions, optimized for frequent use.
+
+### 8.4 M4: Carga automatizada
+- Description: Automated cargo transport missions.
+- Key Features: Autonomous operation, high payload capacity, integration with logistics networks.
+
+## 9. References
 - GAIA AIR Design Philosophy Document (GP-PHIL-001)
 - AMPEL360XWLRGA Preliminary Design Review Documentation (GP-AM-PDR-001)
 - Alternative Energy Harvesting and Control System Specification (GP-AM-EDR-28-004)

--- a/docs/GP-AM/EDR/00/GP-AM-EDR-00-002.md
+++ b/docs/GP-AM/EDR/00/GP-AM-EDR-00-002.md
@@ -15,7 +15,8 @@
 5. [Document Control and Revision Process](#5-document-control-and-revision-process)
 6. [Cross-Reference System](#6-cross-reference-system)
 7. [Digital Documentation Platform](#7-digital-documentation-platform)
-8. [References](#8-references)
+8. [Mission Classification](#8-mission-classification)
+9. [References](#9-references)
 
 ## 1. Introduction
 ### 1.1 Purpose
@@ -171,7 +172,24 @@ Documentation security includes:
 - Secure backup and recovery
 - Integration with i-Aher0 security module
 
-## 8. References
+## 8. Mission Classification
+### 8.1 M1: Suborbital
+- Description: Missions that involve suborbital flights, typically for research, tourism, or short-duration space missions.
+- Key Features: High-altitude flight capabilities, rapid ascent and descent, minimal time in space.
+
+### 8.2 M2: Orbital
+- Description: Missions that involve placing payloads or crew into orbit around Earth.
+- Key Features: Sustained orbital flight, re-entry capabilities, long-duration space missions.
+
+### 8.3 M3: Vuelo comercial
+- Description: Commercial flights for passenger and cargo transport.
+- Key Features: High efficiency, low emissions, optimized for frequent use.
+
+### 8.4 M4: Carga automatizada
+- Description: Automated cargo transport missions.
+- Key Features: Autonomous operation, high payload capacity, integration with logistics networks.
+
+## 9. References
 - COAFI Master Framework Document (COAFI-MASTER-001)
 - ATA Specification 100/2200 Guidelines
 - GAIA AIR Documentation Standards (GP-DOC-STD-001)

--- a/docs/GP-AM/EDR/00/GP-AM-EDR-00-003.md
+++ b/docs/GP-AM/EDR/00/GP-AM-EDR-00-003.md
@@ -15,7 +15,8 @@
 5. [Means of Compliance](#5-means-of-compliance)
 6. [Certification Plan](#6-certification-plan)
 7. [Compliance Checklist](#7-compliance-checklist)
-8. [References](#8-references)
+8. [Mission Classification](#8-mission-classification)
+9. [References](#9-references)
 
 ## 1. Introduction
 ### 1.1 Purpose
@@ -184,7 +185,24 @@ Compliance status is tracked through:
 - Integration with project management tools
 - Automated notification of regulatory changes
 
-## 8. References
+## 8. Mission Classification
+### 8.1 M1: Suborbital
+- Description: Missions that involve suborbital flights, typically for research, tourism, or short-duration space missions.
+- Key Features: High-altitude flight capabilities, rapid ascent and descent, minimal time in space.
+
+### 8.2 M2: Orbital
+- Description: Missions that involve placing payloads or crew into orbit around Earth.
+- Key Features: Sustained orbital flight, re-entry capabilities, long-duration space missions.
+
+### 8.3 M3: Vuelo comercial
+- Description: Commercial flights for passenger and cargo transport.
+- Key Features: High efficiency, low emissions, optimized for frequent use.
+
+### 8.4 M4: Carga automatizada
+- Description: Automated cargo transport missions.
+- Key Features: Autonomous operation, high payload capacity, integration with logistics networks.
+
+## 9. References
 - EASA CS-25 (Large Aeroplanes)
 - FAA 14 CFR Part 25 (Transport Category Airplanes)
 - GAIA AIR Certification Strategy (GP-CERT-STR-001)

--- a/docs/GP-AM/EDR/05/GP-AM-EDR-05-001.md
+++ b/docs/GP-AM/EDR/05/GP-AM-EDR-05-001.md
@@ -15,7 +15,8 @@
 5. [Inspection Intervals](#5-inspection-intervals)
 6. [Special Maintenance Requirements](#6-special-maintenance-requirements)
 7. [Maintenance Documentation](#7-maintenance-documentation)
-8. [References](#8-references)
+8. [Mission Classification](#8-mission-classification)
+9. [References](#9-references)
 
 ## 1. Introduction
 ### 1.1 Purpose
@@ -281,7 +282,24 @@ The maintenance program undergoes regular review and revision:
 - Reliability data analysis
 - Technology updates
 
-## 8. References
+## 8. Mission Classification
+### 8.1 M1: Suborbital
+- Description: Missions that involve suborbital flights, typically for research, tourism, or short-duration space missions.
+- Key Features: High-altitude flight capabilities, rapid ascent and descent, minimal time in space.
+
+### 8.2 M2: Orbital
+- Description: Missions that involve placing payloads or crew into orbit around Earth.
+- Key Features: Sustained orbital flight, re-entry capabilities, long-duration space missions.
+
+### 8.3 M3: Vuelo comercial
+- Description: Commercial flights for passenger and cargo transport.
+- Key Features: High efficiency, low emissions, optimized for frequent use.
+
+### 8.4 M4: Carga automatizada
+- Description: Automated cargo transport missions.
+- Key Features: Autonomous operation, high payload capacity, integration with logistics networks.
+
+## 9. References
 - AMPEL360XWLRGA Maintenance Planning Document (GP-AM-MPD-001)
 - Maintenance Review Board Report (GP-AM-MRBR-001)
 - EASA Part-M Continuing Airworthiness Requirements

--- a/docs/GP-AM/EDR/05/GP-AM-EDR-05-002.md
+++ b/docs/GP-AM/EDR/05/GP-AM-EDR-05-002.md
@@ -15,7 +15,8 @@
 5. [Predictive Analytics Models](#5-predictive-analytics-models)
 6. [Implementation Strategy](#6-implementation-strategy)
 7. [Validation and Performance Metrics](#7-validation-and-performance-metrics)
-8. [References](#8-references)
+8. [Mission Classification](#8-mission-classification)
+9. [References](#9-references)
 
 ## 1. Introduction
 ### 1.1 Purpose
@@ -350,7 +351,24 @@ The i-Aher0 module ensures:
 - Lifecycle cost impact (target: 20% reduction)
 - Revenue impact from improved availability (target: 3% increase)
 
-## 8. References
+## 8. Mission Classification
+### 8.1 M1: Suborbital
+- Description: Missions that involve suborbital flights, typically for research, tourism, or short-duration space missions.
+- Key Features: High-altitude flight capabilities, rapid ascent and descent, minimal time in space.
+
+### 8.2 M2: Orbital
+- Description: Missions that involve placing payloads or crew into orbit around Earth.
+- Key Features: Sustained orbital flight, re-entry capabilities, long-duration space missions.
+
+### 8.3 M3: Vuelo comercial
+- Description: Commercial flights for passenger and cargo transport.
+- Key Features: High efficiency, low emissions, optimized for frequent use.
+
+### 8.4 M4: Carga automatizada
+- Description: Automated cargo transport missions.
+- Key Features: Autonomous operation, high payload capacity, integration with logistics networks.
+
+## 9. References
 - i-Aher0 Architecture Document (GPGM-IAHER-06XX-001-A)
 - Central Maintenance System Specification (GP-AM-EDR-45-001)
 - Digital Twin Interface Specification (GP-DT-IF-001)

--- a/docs/GP-AM/EDR/05/GP-AM-EDR-05-004.md
+++ b/docs/GP-AM/EDR/05/GP-AM-EDR-05-004.md
@@ -15,7 +15,8 @@
 5. [Systems Components](#5-systems-components)
 6. [Life-Limited Parts Management](#6-life-limited-parts-management)
 7. [Time-Limit Validation and Extension](#7-time-limit-validation-and-extension)
-8. [References](#8-references)
+8. [Mission Classification](#8-mission-classification)
+9. [References](#9-references)
 
 ## 1. Introduction
 ### 1.1 Purpose
@@ -315,7 +316,24 @@ Contingency measures include:
 - Operational restrictions if required
 - Temporary extensions with enhanced monitoring
 
-## 8. References
+## 8. Mission Classification
+### 8.1 M1: Suborbital
+- Description: Missions that involve suborbital flights, typically for research, tourism, or short-duration space missions.
+- Key Features: High-altitude flight capabilities, rapid ascent and descent, minimal time in space.
+
+### 8.2 M2: Orbital
+- Description: Missions that involve placing payloads or crew into orbit around Earth.
+- Key Features: Sustained orbital flight, re-entry capabilities, long-duration space missions.
+
+### 8.3 M3: Vuelo comercial
+- Description: Commercial flights for passenger and cargo transport.
+- Key Features: High efficiency, low emissions, optimized for frequent use.
+
+### 8.4 M4: Carga automatizada
+- Description: Automated cargo transport missions.
+- Key Features: Autonomous operation, high payload capacity, integration with logistics networks.
+
+## 9. References
 - Airworthiness Limitations Section (GP-AM-ALS-001)
 - Component Maintenance Manuals (GP-AM-CMM-series)
 - Structural Significant Items List (GP-AM-SSIL-001)

--- a/docs/GP-AM/EDR/05/GP-AM-EDR-05-005.md
+++ b/docs/GP-AM/EDR/05/GP-AM-EDR-05-005.md
@@ -15,7 +15,8 @@
 5. [Aircraft Systems Life Cycle Analysis](#5-aircraft-systems-life-cycle-analysis)
 6. [Economic and Operational Considerations](#6-economic-and-operational-considerations)
 7. [Life Extension Strategies](#7-life-extension-strategies)
-8. [References](#8-references)
+8. [Mission Classification](#8-mission-classification)
+9. [References](#9-references)
 
 ## 1. Introduction
 ### 1.1 Purpose
@@ -431,7 +432,24 @@ The following tools and techniques are employed:
 - Control system optimization
 - Energy harvesting integration
 
-## 8. References
+## 8. Mission Classification
+### 8.1 M1: Suborbital
+- Description: Missions that involve suborbital flights, typically for research, tourism, or short-duration space missions.
+- Key Features: High-altitude flight capabilities, rapid ascent and descent, minimal time in space.
+
+### 8.2 M2: Orbital
+- Description: Missions that involve placing payloads or crew into orbit around Earth.
+- Key Features: Sustained orbital flight, re-entry capabilities, long-duration space missions.
+
+### 8.3 M3: Vuelo comercial
+- Description: Commercial flights for passenger and cargo transport.
+- Key Features: High efficiency, low emissions, optimized for frequent use.
+
+### 8.4 M4: Carga automatizada
+- Description: Automated cargo transport missions.
+- Key Features: Autonomous operation, high payload capacity, integration with logistics networks.
+
+## 9. References
 - Fatigue and Damage Tolerance Analysis Report (GP-AM-FDTAR-001)
 - Quantum Propulsion Life Substantiation Report (GP-AM-EDR-72-Q01-007)
 - Alternative Energy Harvesting System Life Test Report (GP-AM-EDR-28-AEHS-005)

--- a/docs/GP-AM/EDR/05/GP-AM-EDR-05-006.md
+++ b/docs/GP-AM/EDR/05/GP-AM-EDR-05-006.md
@@ -15,7 +15,8 @@
 5. [Systems Airworthiness Limitations](#5-systems-airworthiness-limitations)
 6. [Operational Limitations](#6-operational-limitations)
 7. [Certification Maintenance Requirements](#7-certification-maintenance-requirements)
-8. [References](#8-references)
+8. [Mission Classification](#8-mission-classification)
+9. [References](#9-references)
 
 ## 1. Introduction
 ### 1.1 Purpose
@@ -380,7 +381,24 @@ The following powerplant Certification Maintenance Requirements are mandatory:
 | Thrust Reverser | Verification of reverser lockout integrity | 1,500 FC | ±75 FC | CS 25.933 |
 | Engine Control | Verification of thrust control integrity | 1,000 FH | ±50 FH | CS 25.1141 |
 
-## 8. References
+## 8. Mission Classification
+### 8.1 M1: Suborbital
+- Description: Missions that involve suborbital flights, typically for research, tourism, or short-duration space missions.
+- Key Features: High-altitude flight capabilities, rapid ascent and descent, minimal time in space.
+
+### 8.2 M2: Orbital
+- Description: Missions that involve placing payloads or crew into orbit around Earth.
+- Key Features: Sustained orbital flight, re-entry capabilities, long-duration space missions.
+
+### 8.3 M3: Vuelo comercial
+- Description: Commercial flights for passenger and cargo transport.
+- Key Features: High efficiency, low emissions, optimized for frequent use.
+
+### 8.4 M4: Carga automatizada
+- Description: Automated cargo transport missions.
+- Key Features: Autonomous operation, high payload capacity, integration with logistics networks.
+
+## 9. References
 - Airworthiness & Certification Requirements Report (GP-AM-EDR-00-003)
 - Scheduled Maintenance Program Specification (GP-AM-EDR-05-001)
 - Component Lifing & Time-Limit Data Report (GP-AM-EDR-05-004)

--- a/docs/GP-AM/EDR/05/GP-AM-EDR-05-007.md
+++ b/docs/GP-AM/EDR/05/GP-AM-EDR-05-007.md
@@ -15,7 +15,8 @@
 5. [Certification Schedule](#5-certification-schedule)
 6. [Certification Organization](#6-certification-organization)
 7. [Post-Certification Activities](#7-post-certification-activities)
-8. [References](#8-references)
+8. [Mission Classification](#8-mission-classification)
+9. [References](#9-references)
 
 ## 1. Introduction
 ### 1.1 Purpose
@@ -388,7 +389,24 @@ The following strategies will mitigate certification schedule risks:
 - Quantum propulsion operations
 - AEHS operations
 
-## 8. References
+## 8. Mission Classification
+### 8.1 M1: Suborbital
+- Description: Missions that involve suborbital flights, typically for research, tourism, or short-duration space missions.
+- Key Features: High-altitude flight capabilities, rapid ascent and descent, minimal time in space.
+
+### 8.2 M2: Orbital
+- Description: Missions that involve placing payloads or crew into orbit around Earth.
+- Key Features: Sustained orbital flight, re-entry capabilities, long-duration space missions.
+
+### 8.3 M3: Vuelo comercial
+- Description: Commercial flights for passenger and cargo transport.
+- Key Features: High efficiency, low emissions, optimized for frequent use.
+
+### 8.4 M4: Carga automatizada
+- Description: Automated cargo transport missions.
+- Key Features: Autonomous operation, high payload capacity, integration with logistics networks.
+
+## 9. References
 - Airworthiness & Certification Requirements Report (GP-AM-EDR-00-003)
 - Airworthiness Limitations Document (GP-AM-EDR-05-006)
 - EASA Certification Memoranda

--- a/docs/GP-AM/EDR/06/GP-AM-EDR-06-001.md
+++ b/docs/GP-AM/EDR/06/GP-AM-EDR-06-001.md
@@ -15,7 +15,8 @@
 5. [Critical Measurement Points](#5-critical-measurement-points)
 6. [Tolerance Specifications](#6-tolerance-specifications)
 7. [Dimensional Verification Methods](#7-dimensional-verification-methods)
-8. [References](#8-references)
+8. [Mission Classification](#8-mission-classification)
+9. [References](#9-references)
 
 ## 1. Introduction
 ### 1.1 Purpose
@@ -388,7 +389,24 @@ Water lines are numbered in centimeters from the Z=0 reference plane. Key water 
 - Trend analysis
 - Final dimensional compliance statement
 
-## 8. References
+## 8. Mission Classification
+### 8.1 M1: Suborbital
+- Description: Missions that involve suborbital flights, typically for research, tourism, or short-duration space missions.
+- Key Features: High-altitude flight capabilities, rapid ascent and descent, minimal time in space.
+
+### 8.2 M2: Orbital
+- Description: Missions that involve placing payloads or crew into orbit around Earth.
+- Key Features: Sustained orbital flight, re-entry capabilities, long-duration space missions.
+
+### 8.3 M3: Vuelo comercial
+- Description: Commercial flights for passenger and cargo transport.
+- Key Features: High efficiency, low emissions, optimized for frequent use.
+
+### 8.4 M4: Carga automatizada
+- Description: Automated cargo transport missions.
+- Key Features: Autonomous operation, high payload capacity, integration with logistics networks.
+
+## 9. References
 - Aircraft General Arrangement Drawing (GP-AM-DRW-00-001)
 - Calibration & Measurement Procedures Document (GP-AM-EDR-06-002)
 - Structural Integration Analysis Report (GP-AM-EDR-06-003)

--- a/docs/GP-AM/EDR/06/GP-AM-EDR-06-002.md
+++ b/docs/GP-AM/EDR/06/GP-AM-EDR-06-002.md
@@ -15,7 +15,8 @@
 5. [Measurement Procedures](#5-measurement-procedures)
 6. [Environmental Controls](#6-environmental-controls)
 7. [Personnel Qualifications](#7-personnel-qualifications)
-8. [References](#8-references)
+8. [Mission Classification](#8-mission-classification)
+9. [References](#9-references)
 
 ## 1. Introduction
 ### 1.1 Purpose
@@ -480,7 +481,24 @@ For critical measurements:
 5. Receive certification approval from Metrology Manager
 6. Maintain certification through continuing education and periodic reassessment
 
-## 8. References
+## 8. Mission Classification
+### 8.1 M1: Suborbital
+- Description: Missions that involve suborbital flights, typically for research, tourism, or short-duration space missions.
+- Key Features: High-altitude flight capabilities, rapid ascent and descent, minimal time in space.
+
+### 8.2 M2: Orbital
+- Description: Missions that involve placing payloads or crew into orbit around Earth.
+- Key Features: Sustained orbital flight, re-entry capabilities, long-duration space missions.
+
+### 8.3 M3: Vuelo comercial
+- Description: Commercial flights for passenger and cargo transport.
+- Key Features: High efficiency, low emissions, optimized for frequent use.
+
+### 8.4 M4: Carga automatizada
+- Description: Automated cargo transport missions.
+- Key Features: Autonomous operation, high payload capacity, integration with logistics networks.
+
+## 9. References
 - Dimensional Data Report (GP-AM-EDR-06-001)
 - Structural Integration Analysis Report (GP-AM-EDR-06-003)
 - Measurement Point Definitions Table (GP-AM-EDR-06-006)

--- a/docs/GP-AM/EDR/06/GP-AM-EDR-06-003.md
+++ b/docs/GP-AM/EDR/06/GP-AM-EDR-06-003.md
@@ -15,7 +15,8 @@
 5. [Systems Integration](#5-systems-integration)
 6. [Tolerance Stack-Up Analysis](#6-tolerance-stack-up-analysis)
 7. [Integration Risk Assessment](#7-integration-risk-assessment)
-8. [References](#8-references)
+8. [Mission Classification](#8-mission-classification)
+9. [References](#9-references)
 
 ## 1. Introduction
 ### 1.1 Purpose
@@ -470,7 +471,24 @@ The following contingency plans address potential manufacturing issues:
 | MR-004 | Backup tooling deployment, manual operations | Tool failure | Medium |
 | MR-005 | Temporary assembly suspension, portable environment | Control failure | High |
 
-## 8. References
+## 8. Mission Classification
+### 8.1 M1: Suborbital
+- Description: Missions that involve suborbital flights, typically for research, tourism, or short-duration space missions.
+- Key Features: High-altitude flight capabilities, rapid ascent and descent, minimal time in space.
+
+### 8.2 M2: Orbital
+- Description: Missions that involve placing payloads or crew into orbit around Earth.
+- Key Features: Sustained orbital flight, re-entry capabilities, long-duration space missions.
+
+### 8.3 M3: Vuelo comercial
+- Description: Commercial flights for passenger and cargo transport.
+- Key Features: High efficiency, low emissions, optimized for frequent use.
+
+### 8.4 M4: Carga automatizada
+- Description: Automated cargo transport missions.
+- Key Features: Autonomous operation, high payload capacity, integration with logistics networks.
+
+## 9. References
 - Dimensional Data Report (GP-AM-EDR-06-001)
 - Calibration & Measurement Procedures Document (GP-AM-EDR-06-002)
 - Internal Compartment Layout Document (GP-AM-EDR-06-004)

--- a/docs/GP-AM/EDR/06/GP-AM-EDR-06-004.md
+++ b/docs/GP-AM/EDR/06/GP-AM-EDR-06-004.md
@@ -15,7 +15,8 @@
 5. [Equipment Compartments](#5-equipment-compartments)
 6. [Systems Integration](#6-systems-integration)
 7. [Access and Maintenance Provisions](#7-access-and-maintenance-provisions)
-8. [References](#8-references)
+8. [Mission Classification](#8-mission-classification)
+9. [References](#9-references)
 
 ## 1. Introduction
 ### 1.1 Purpose
@@ -459,7 +460,24 @@ The AMPEL360XWLRGA flight deck is designed with an advanced glass cockpit config
 - Built-in test equipment: Integrated with major systems
 - Diagnostic display panels: Equipment bays and flight deck
 
-## 8. References
+## 8. Mission Classification
+### 8.1 M1: Suborbital
+- Description: Missions that involve suborbital flights, typically for research, tourism, or short-duration space missions.
+- Key Features: High-altitude flight capabilities, rapid ascent and descent, minimal time in space.
+
+### 8.2 M2: Orbital
+- Description: Missions that involve placing payloads or crew into orbit around Earth.
+- Key Features: Sustained orbital flight, re-entry capabilities, long-duration space missions.
+
+### 8.3 M3: Vuelo comercial
+- Description: Commercial flights for passenger and cargo transport.
+- Key Features: High efficiency, low emissions, optimized for frequent use.
+
+### 8.4 M4: Carga automatizada
+- Description: Automated cargo transport missions.
+- Key Features: Autonomous operation, high payload capacity, integration with logistics networks.
+
+## 9. References
 - Dimensional Data Report (GP-AM-EDR-06-001)
 - Calibration & Measurement Procedures Document (GP-AM-EDR-06-002)
 - Structural Integration Analysis Report (GP-AM-EDR-06-003)

--- a/docs/GP-AM/EDR/06/GP-AM-EDR-06-005.md
+++ b/docs/GP-AM/EDR/06/GP-AM-EDR-06-005.md
@@ -15,7 +15,8 @@
 5. [Compartment-Specific Calculations](#5-compartment-specific-calculations)
 6. [System Space Allocations](#6-system-space-allocations)
 7. [Weight and Balance Implications](#7-weight-and-balance-implications)
-8. [References](#8-references)
+8. [Mission Classification](#8-mission-classification)
+9. [References](#9-references)
 
 ## 1. Introduction
 ### 1.1 Purpose
@@ -380,7 +381,24 @@ All dimensions reference the aircraft coordinate system:
 | Bulk Cargo | 6.1 m³ | 150-250 kg/m³ | 915-1,525 kg |
 | **Total** | **34.7 m³** | **150-250 kg/m³** | **5,205-8,675 kg** |
 
-## 8. References
+## 8. Mission Classification
+### 8.1 M1: Suborbital
+- Description: Missions that involve suborbital flights, typically for research, tourism, or short-duration space missions.
+- Key Features: High-altitude flight capabilities, rapid ascent and descent, minimal time in space.
+
+### 8.2 M2: Orbital
+- Description: Missions that involve placing payloads or crew into orbit around Earth.
+- Key Features: Sustained orbital flight, re-entry capabilities, long-duration space missions.
+
+### 8.3 M3: Vuelo comercial
+- Description: Commercial flights for passenger and cargo transport.
+- Key Features: High efficiency, low emissions, optimized for frequent use.
+
+### 8.4 M4: Carga automatizada
+- Description: Automated cargo transport missions.
+- Key Features: Autonomous operation, high payload capacity, integration with logistics networks.
+
+## 9. References
 - Dimensional Data Report (GP-AM-EDR-06-001)
 - Calibration & Measurement Procedures Document (GP-AM-EDR-06-002)
 - Structural Integration Analysis Report (GP-AM-EDR-06-003)


### PR DESCRIPTION
Add a section for mission classification (M1, M2, M3, M4) to multiple documentation files.

* **Mission Classification Section:**
  - Add a new section for mission classification (M1, M2, M3, M4) in `docs/GP-AM/EDR/00/GP-AM-EDR-00-001.md`, `docs/GP-AM/EDR/00/GP-AM-EDR-00-002.md`, `docs/GP-AM/EDR/00/GP-AM-EDR-00-003.md`, `docs/GP-AM/EDR/05/GP-AM-EDR-05-001.md`, `docs/GP-AM/EDR/05/GP-AM-EDR-05-002.md`, `docs/GP-AM/EDR/05/GP-AM-EDR-05-004.md`, `docs/GP-AM/EDR/05/GP-AM-EDR-05-005.md`, `docs/GP-AM/EDR/05/GP-AM-EDR-05-006.md`, `docs/GP-AM/EDR/05/GP-AM-EDR-05-007.md`, `docs/GP-AM/EDR/06/GP-AM-EDR-06-001.md`, `docs/GP-AM/EDR/06/GP-AM-EDR-06-002.md`.
  - Include details for each mission type (M1: Suborbital, M2: Orbital, M3: Vuelo comercial, M4: Carga automatizada).

* **Table of Contents Update:**
  - Update the table of contents in each modified file to reflect the new mission classification section.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Robbbo-T/Robbbo-T/pull/38?shareId=8d8a2964-9cde-48e3-97be-91b5e30b6c17).

## Summary by Sourcery

Adds a new 'Mission Classification' section to multiple EDR documentation files, detailing mission types M1 through M4.

Documentation:
- Adds a new section for mission classification (M1, M2, M3, M4) in multiple documentation files.
- Updates the table of contents in each modified file to reflect the new mission classification section.