### PR TITLE
Add year-end review report generation

### DIFF
--- a/COAFI/CMS-KIT/app/backend-fastapi/main.py
+++ b/COAFI/CMS-KIT/app/backend-fastapi/main.py
@@ -10,6 +10,7 @@ import uvicorn
 
 # Import your custom routers
 from routers.services import semantic_bridge  # <-- asegúrate que semantic_bridge.py tiene router = APIRouter()
+from routers import review  # Import the new review router
 
 app = FastAPI(
     title="COAFI Quantum Memory API",
@@ -28,6 +29,7 @@ app.add_middleware(
 
 # Mount routers
 app.include_router(semantic_bridge.router, prefix="/semantic-query", tags=["Semantic Query"])
+app.include_router(review.router, prefix="/review", tags=["Year-End Review"])  # Include the new review router
 
 # Health check route
 @app.get("/")

--- a/COAFI/CMS-KIT/app/backend-fastapi/routers/__init__.py
+++ b/COAFI/CMS-KIT/app/backend-fastapi/routers/__init__.py
@@ -1,0 +1,3 @@
+from . import review
+
+__all__ = ["review"]


### PR DESCRIPTION
Add a new route to handle the year-end review report.

* **main.py**
  - Import the new review router.
  - Include the new review router in the main application.

* **routers/__init__.py**
  - Import the new review router.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Robbbo-T/Robbbo-T/pull/51?shareId=2b0ca3f3-1104-4dff-9920-624722c41dcc).

## Summary by Sourcery

Add support for year-end review report generation by integrating a new router into the FastAPI application

New Features:
- Introduce a new router for handling year-end review report generation

Enhancements:
- Extend the application's routing configuration to include year-end review functionality