### PR TITLE
Add COAFI Table of Contents with relative links

### DIFF
--- a/docs/GP-AM/00/GP-AM-EDR-00-001-SDD-A.md
+++ b/docs/GP-AM/00/GP-AM-EDR-00-001-SDD-A.md
@@ -4,6 +4,8 @@
 
 The **GP-AM-EDR-00-001-SDD-A** is the foundational System Description Document (SDD) for the AMPEL360XWLRGA aircraft. This comprehensive technical document provides a complete system-level description of the entire aircraft, serving as the primary reference for understanding the aircraft's architecture, systems integration, and operational capabilities.
 
+For a detailed Table of Contents for all COAFI Parts (0-VI), refer to the [COAFI Index](../../COAFI/Index.md).
+
 ## Document Purpose
 
 This SDD serves multiple critical functions within the AMPEL360XWLRGA documentation framework:

--- a/docs/GP-AM/00/GP-AM-EDR-00-002-OV-A.md
+++ b/docs/GP-AM/00/GP-AM-EDR-00-002-OV-A.md
@@ -18,6 +18,8 @@ The scope of this document encompasses:
 - The approach to interface management
 - The implementation strategy for the AMPEL360XWLRGA aircraft
 
+For a detailed Table of Contents for all COAFI Parts (0-VI), refer to the [COAFI Index](../../COAFI/Index.md).
+
 ### 1.2 Document Structure
 
 This document is organized as follows:

--- a/docs/GP-AM/00/GP-AM-EDR-00-003-RPT-A.md
+++ b/docs/GP-AM/00/GP-AM-EDR-00-003-RPT-A.md
@@ -18,6 +18,8 @@ The scope of this document encompasses:
 - The certification roadmap and milestones
 - The safety assessment methodology
 
+For a detailed Table of Contents for all COAFI Parts (0-VI), refer to the [COAFI Index](../../COAFI/Index.md).
+
 ### 1.2 Document Structure
 
 This document is organized as follows:

--- a/docs/GP-AM/05/index.md
+++ b/docs/GP-AM/05/index.md
@@ -28,3 +28,5 @@
 
 #### **GP-PM-EOL-SENSOR-TEMP-001-A: End of Life Protocol (ATA 106)**
 - **[GP-PM-EOL-SENSOR-TEMP-001-A](#ata-106--end-of-life-protocol)**: Dignified Component Functional End of Life Protocol - Temperature Sensors (XYZ-T1)
+
+For a detailed Table of Contents for all COAFI Parts (0-VI), refer to the [COAFI Index](../../COAFI/Index.md).


### PR DESCRIPTION
Add references to the new Table of Contents for all COAFI Parts (0-VI) in relevant documents.

* **docs/GP-AM/00/GP-AM-EDR-00-001-SDD-A.md**
  - Add reference to the COAFI Index in the Document Overview section.
* **docs/GP-AM/00/GP-AM-EDR-00-002-OV-A.md**
  - Add reference to the COAFI Index in the Introduction section.
* **docs/GP-AM/00/GP-AM-EDR-00-003-RPT-A.md**
  - Add reference to the COAFI Index in the Introduction section.
* **docs/GP-AM/05/index.md**
  - Add reference to the COAFI Index in the appropriate section.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Robbbo-T/Robbbo-T?shareId=XXXX-XXXX-XXXX-XXXX).

## Summary by Sourcery

Add references to the COAFI Index in multiple documentation files to provide a detailed Table of Contents for all COAFI Parts (0-VI).

Documentation:
- Add references to the COAFI Index in the Document Overview section of the System Description Document (SDD).
- Include a reference to the COAFI Index in the Introduction section of the Overview document.
- Add a reference to the COAFI Index in the Introduction section of the Report document.
- Update the index document to include a reference to the COAFI Index.