### PR TITLE
Add GAIA Documentation Ecosystem

### DIFF
--- a/.github/workflows/create-repo-structure.yml
+++ b/.github/workflows/create-repo-structure.yml
@@ -22,810 +22,266 @@ jobs:
           mkdir -p api-orchestration/src
           mkdir -p common/src
           mkdir -p docs/diagrams
-          
-      - name: Create package.json
-        run: |
-          cat > package.json << 'EOL'
-          {
-            "name": "api-integration-strategy",
-            "version": "1.0.0",
-            "description": "Comprehensive API Integration Strategy with multiple approaches",
-            "scripts": {
-              "start:adaptation": "node adaptation-layer/src/index.js",
-              "start:facades": "node microservices-facades/src/index.js",
-              "start:transformation": "node transformation-framework/src/index.js",
-              "start:metadata": "node metadata-driven-approach/src/index.js",
-              "start:orchestration": "node api-orchestration/src/index.js",
-              "test": "jest"
-            },
-            "keywords": ["api", "integration", "rest", "graphql", "soap", "facade", "adaptation", "transformation"],
-            "author": "Robbbo-T",
-            "license": "MIT",
-            "dependencies": {
-              "express": "^4.18.2",
-              "axios": "^1.3.4",
-              "graphql": "^16.6.0",
-              "apollo-server-express": "^3.12.0",
-              "soap": "^1.0.0",
-              "protobufjs": "^7.2.3",
-              "ajv": "^8.12.0",
-              "openapi-types": "^12.1.0",
-              "swagger-ui-express": "^4.6.2"
-            },
-            "devDependencies": {
-              "typescript": "^5.0.4",
-              "jest": "^29.5.0",
-              "supertest": "^6.3.3",
-              "@types/express": "^4.17.17",
-              "@types/node": "^18.15.11"
-            }
-          }
-          EOL
-          
-      - name: Create architecture diagram
-        run: |
-          cat > docs/diagrams/architecture-diagram.mmd << 'EOL'
-          graph TD
-              Client[Client Applications] --> Gateway[API Gateway]
-              Gateway --> AL[Adaptation Layer]
-              Gateway --> MSF[Microservices with API Facades]
-              Gateway --> TF[Transformation Framework]
-              Gateway --> MDA[Metadata-Driven Approach]
-              Gateway --> AO[API Orchestration]
-              
-              AL -->|Transforms| Backend1[Backend Services]
-              MSF --> |Routes to| Backend2[Backend Services]
-              TF --> |Converts data for| Backend3[Backend Services]
-              MDA --> |Generates endpoints for| Backend4[Backend Services]
-              AO --> |Orchestrates calls to| Backend5[Backend Services]
-              
-              subgraph "Integration Strategies"
-                  AL
-                  MSF
-                  TF
-                  MDA
-                  AO
-              end
-              
-              subgraph "Backend Systems"
-                  Backend1
-                  Backend2
-                  Backend3
-                  Backend4
-                  Backend5
-              end
-          EOL
-      
-      - name: Create CONTRIBUTING.md
-        run: |
-          cat > CONTRIBUTING.md << 'EOL'
-          # Contributing to API Integration Strategy
-          
-          Thank you for considering contributing to this project! Here's how you can help:
-          
-          ## Code of Conduct
-          
-          This project adheres to a Code of Conduct. By participating, you are expected to uphold this code.
-          
-          ## How to Contribute
-          
-          1. Fork the repository
-          2. Create a feature branch (`git checkout -b feature/amazing-feature`)
-          3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-          4. Push to the branch (`git push origin feature/amazing-feature`)
-          5. Open a Pull Request
-          
-          ## Development Setup
-          
-          ```bash
-          npm install
-          ```
-          
-          ## Testing
-          
-          ```bash
-          npm test
-          ```
-          
-          ## Style Guide
-          
-          Please follow the existing code style and structure.
-          
-          ## Issue Reporting
-          
-          For bug reports or feature requests, please use the GitHub issue tracker.
-          EOL
-          
-      - name: Create LICENSE
-        run: |
-          cat > LICENSE << 'EOL'
-          MIT License
-          
-          Copyright (c) 2025 Robbbo-T
-          
-          Permission is hereby granted, free of charge, to any person obtaining a copy
-          of this software and associated documentation files (the "Software"), to deal
-          in the Software without restriction, including without limitation the rights
-          to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-          copies of the Software, and to permit persons to whom the Software is
-          furnished to do so, subject to the following conditions:
-          
-          The above copyright notice and this permission notice shall be included in all
-          copies or substantial portions of the Software.
-          
-          THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-          IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-          FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-          AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-          LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-          OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-          SOFTWARE.
-          EOL
-          
-      - name: Initialize approach directories with READMEs
-        run: |
-          for dir in adaptation-layer microservices-facades transformation-framework metadata-driven-approach api-orchestration common; do
-            cat > ${dir}/README.md << EOL
-          # ${dir}
-          
-          This directory contains the implementation for the ${dir} approach of the API Integration Strategy.
-          
-          ## Overview
-          
-          TODO: Add specific information about this approach.
-          
-          ## Getting Started
-          
-          \`\`\`bash
-          npm install
-          npm run start:${dir#*/}
-          \`\`\`
-          
-          ## Architecture
-          
-          TODO: Add architecture diagram specific to this approach.
-          
-          ## Implementation Details
-          
-          TODO: Add implementation details.
-          EOL
-          done
-          
-      - name: Create API Orchestration sample
-        run: |
-          mkdir -p api-orchestration/src/examples
-          cat > api-orchestration/src/examples/OrderProcessingOrchestration.ts << 'EOL'
-          import { OrchestrationBuilder } from '../OrchestrationBuilder';
-          
-          /**
-           * Example Order Processing Orchestration that coordinates between
-           * multiple backend services to process an order
-           */
-          export function createOrderProcessingOrchestration() {
-            const builder = new OrchestrationBuilder('order-processing');
-            
-            return builder
-              .step('validate-inventory')
-                .callService('inventory-service', '/api/check-availability')
-                .withRequestTransform((request) => ({
-                  productIds: request.items.map(item => item.productId),
-                  quantities: request.items.map(item => item.quantity)
-                }))
-                .withResponseCondition((response) => response.allAvailable)
-              .step('process-payment')
-                .callService('payment-service', '/api/payments')
-                .withRequestTransform((request, context) => ({
-                  amount: request.totalAmount,
-                  currency: request.currency,
-                  paymentMethod: request.paymentDetails,
-                  orderId: context.orderId
-                }))
-              .step('reserve-inventory')
-                .callService('inventory-service', '/api/reserve')
-                .withRequestTransform((request, context) => ({
-                  orderId: context.orderId,
-                  items: request.items
-                }))
-              .step('create-shipment')
-                .callService('logistics-service', '/api/shipments')
-                .withRequestTransform((request, context) => ({
-                  orderId: context.orderId,
-                  address: request.shippingAddress,
-                  items: request.items
-                }))
-              .step('send-confirmation')
-                .callService('notification-service', '/api/notify')
-                .withRequestTransform((request, context) => ({
-                  to: request.customerEmail,
-                  template: 'order-confirmation',
-                  data: {
-                    orderId: context.orderId,
-                    items: request.items,
-                    total: request.totalAmount,
-                    shipmentId: context.shipmentId
-                  }
-                }))
-              .build();
-          }
-          EOL
-          
-      - name: Validate XML against S1000D Schema
-        run: |
-          xmllint --noout --schema schemas/S1000D_6.0_Schema.xsd data/ATA71.xml
-
-      - name: Run BREX Compliance Check
-        run: |
-          python tools/brex_check.py rules/ProjectBREX.xml data/ATA71.xml
-
-      - name: Commit and push changes
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git add .
-          git commit -m "Initialize API Integration Strategy repository structure"
-          git push
-
-      - name: Create Aircraft General – System Description (ATA 00)
-        run: |
+          mkdir -p docs/air/00
+          mkdir -p docs/air/01
+          mkdir -p docs/air/02
+          mkdir -p docs/air/03
+          mkdir -p docs/air/04
+          mkdir -p docs/air/05
+          mkdir -p docs/air/06
+          mkdir -p docs/air/07
+          mkdir -p docs/air/08
+          mkdir -p docs/air/09
+          mkdir -p docs/air/10
+          mkdir -p docs/air/11
+          mkdir -p docs/air/12
+          mkdir -p docs/air/13
+          mkdir -p docs/air/14
+          mkdir -p docs/air/15
+          mkdir -p docs/air/16
+          mkdir -p docs/air/17
+          mkdir -p docs/air/18
+          mkdir -p docs/air/19
+          mkdir -p docs/air/20
+          mkdir -p docs/air/21
+          mkdir -p docs/air/22
+          mkdir -p docs/air/23
+          mkdir -p docs/air/24
+          mkdir -p docs/air/25
+          mkdir -p docs/air/26
+          mkdir -p docs/air/27
+          mkdir -p docs/air/28
+          mkdir -p docs/air/29
+          mkdir -p docs/air/30
+          mkdir -p docs/air/31
+          mkdir -p docs/air/32
+          mkdir -p docs/air/33
+          mkdir -p docs/air/34
+          mkdir -p docs/air/35
+          mkdir -p docs/air/36
+          mkdir -p docs/air/37
+          mkdir -p docs/air/38
+          mkdir -p docs/air/39
+          mkdir -p docs/air/40
+          mkdir -p docs/air/41
+          mkdir -p docs/air/42
+          mkdir -p docs/air/43
+          mkdir -p docs/air/44
+          mkdir -p docs/air/45
+          mkdir -p docs/air/46
+          mkdir -p docs/air/47
+          mkdir -p docs/air/48
+          mkdir -p docs/air/49
+          mkdir -p docs/air/50
+          mkdir -p docs/air/51
+          mkdir -p docs/air/52
+          mkdir -p docs/air/53
+          mkdir -p docs/air/54
+          mkdir -p docs/air/55
+          mkdir -p docs/air/56
+          mkdir -p docs/air/57
+          mkdir -p docs/air/58
+          mkdir -p docs/air/59
+          mkdir -p docs/air/60
+          mkdir -p docs/air/61
+          mkdir -p docs/air/62
+          mkdir -p docs/air/63
+          mkdir -p docs/air/64
+          mkdir -p docs/air/65
+          mkdir -p docs/air/66
+          mkdir -p docs/air/67
+          mkdir -p docs/air/68
+          mkdir -p docs/air/69
+          mkdir -p docs/air/70
+          mkdir -p docs/air/71
+          mkdir -p docs/air/72
+          mkdir -p docs/air/73
+          mkdir -p docs/air/74
+          mkdir -p docs/air/75
+          mkdir -p docs/air/76
+          mkdir -p docs/air/77
+          mkdir -p docs/air/78
+          mkdir -p docs/air/79
+          mkdir -p docs/air/80
+          mkdir -p docs/air/81
+          mkdir -p docs/air/82
+          mkdir -p docs/air/83
+          mkdir -p docs/air/84
+          mkdir -p docs/air/85
+          mkdir -p docs/air/86
+          mkdir -p docs/air/87
+          mkdir -p docs/air/88
+          mkdir -p docs/air/89
+          mkdir -p docs/air/90
+          mkdir -p docs/air/91
+          mkdir -p docs/air/92
+          mkdir -p docs/air/93
+          mkdir -p docs/air/94
+          mkdir -p docs/air/95
+          mkdir -p docs/air/96
+          mkdir -p docs/air/97
+          mkdir -p docs/air/98
+          mkdir -p docs/air/99
+          mkdir -p docs/space/ss/10
+          mkdir -p docs/space/ss/20
+          mkdir -p docs/space/ss/30
+          mkdir -p docs/space/ss/40
+          mkdir -p docs/space/ss/50
+          mkdir -p docs/space/ss/60
+          mkdir -p docs/space/ss/70
+          mkdir -p docs/space/ss/80
+          mkdir -p docs/space/ss/90
+          mkdir -p docs/space/mo/10
+          mkdir -p docs/space/mo/20
+          mkdir -p docs/space/mo/30
+          mkdir -p docs/space/mo/40
+          mkdir -p docs/space/mo/50
+          mkdir -p docs/space/mo/60
+          mkdir -p docs/space/mo/70
+          mkdir -p docs/space/mo/80
+          mkdir -p docs/space/mo/90
+          mkdir -p docs/space/se/10
+          mkdir -p docs/space/se/20
+          mkdir -p docs/space/se/30
+          mkdir -p docs/space/se/40
+          mkdir -p docs/space/se/50
+          mkdir -p docs/space/se/60
+          mkdir -p docs/space/se/70
+          mkdir -p docs/space/se/80
+          mkdir -p docs/space/se/90
+          mkdir -p docs/space/ls/10
+          mkdir -p docs/space/ls/20
+          mkdir -p docs/space/ls/30
+          mkdir -p docs/space/ls/40
+          mkdir -p docs/space/ls/50
+          mkdir -p docs/space/ls/60
+          mkdir -p docs/space/ls/70
+          mkdir -p docs/space/ls/80
+          mkdir -p docs/space/ls/90
+          mkdir -p docs/space/sr/10
+          mkdir -p docs/space/sr/20
+          mkdir -p docs/space/sr/30
+          mkdir -p docs/space/sr/40
+          mkdir -p docs/space/sr/50
+          mkdir -p docs/space/sr/60
+          mkdir -p docs/space/sr/70
+          mkdir -p docs/space/sr/80
+          mkdir -p docs/space/sr/90
+          mkdir -p docs/common/fd
+          mkdir -p docs/common/cn
+          mkdir -p docs/common/gb
+          mkdir -p docs/common/supl
+          mkdir -p docs/common/rame
+          mkdir -p docs/common/pm
+          mkdir -p docs/common/ds
+          mkdir -p docs/common/dimensions
+          mkdir -p docs/common/rs
           mkdir -p docs/GP-AM/00
-          cat > docs/GP-AM/00/GP-AM-AMPEL-0100-00-001-A.md << 'EOL'
-          # GP-AM-AMPEL-0100-00-001-A: Aircraft General – System Description (ATA 00)
-
-          **Document ID:** GP-AM-AMPEL-0100-00-001-A  
-          **Revision:** A  
-          **Status:** Released  
-          **Date:** 2025-01-15  
-
-          ## 1. Introduction
-
-          ### 1.1 Purpose and Scope
-
-          This document provides a comprehensive overview of the AMPEL360XWLRGA aircraft system. It serves as the primary entry point to the complete aircraft documentation and establishes the foundation for all subsequent technical documentation. The scope encompasses the general characteristics, design philosophy, operational concept, and high-level specifications of the aircraft.
-
-          ### 1.2 Document Structure
-
-          This document is organized as follows:
-          - Section 1: Introduction and document overview
-          - Section 2: Aircraft concept and mission profile
-          - Section 3: General characteristics and specifications
-          - Section 4: Design philosophy and innovation areas
-          - Section 5: Operational concept
-          - Section 6: Documentation schema and navigation
-
-          ### 1.3 Applicable Documents
-
-          The following documents form an integral part of this specification:
-
-          - GP-AM-EDR-00-001-SDD-A: Overall Aircraft System Description Document
-          - GP-AM-EDR-00-002-OV-A: COAFI Framework Overview for Part I
-          - GP-AM-EDR-00-003-RPT-A: Airworthiness & Certification Requirements Report
-
-          ### 1.4 Terminology and Abbreviations
-
-          | Abbreviation | Definition |
-          |--------------|------------|
-          | AEHCS | Advanced Energy Harvesting and Conversion System |
-          | ATA | Air Transport Association |
-          | COAFI | Comprehensive Operational and Functional Integration |
-          | CCS | Cryogenic Cooling System |
-          | QEE | Quantum Entanglement Engine |
-          | XWLRGA | Extended Wide Long Range Green Aircraft |
-
-          ## 2. Aircraft Concept and Mission Profile
-
-          ### 2.1 Concept Overview
-
-          The AMPEL360XWLRGA (Atmospheric Multi-Propulsion Eco-Logical 360° Extended Wide Long Range Green Aircraft) represents a revolutionary approach to commercial aviation. It is designed as a 100% green, zero-emission aircraft that integrates conventional aerospace technologies with quantum propulsion systems and advanced sustainable energy solutions.
-
-          The aircraft embodies GAIA Air's commitment to transforming air transportation through radical innovation while maintaining the highest standards of safety, reliability, and operational efficiency.
-
-          ### 2.2 Mission Profile
-
-          The AMPEL360XWLRGA is designed to fulfill the following mission profiles:
-
-          - **Primary Mission**: Long-range commercial passenger transport (up to 12,000 km) with zero direct emissions
-          - **Secondary Mission**: Medium-range high-capacity routes (3,000-6,000 km)
-          - **Tertiary Mission**: Specialized cargo transport for time-sensitive, high-value goods
-
-          The aircraft is optimized for:
-          - Cruise altitude: 10,000-13,000 meters
-          - Cruise speed: Mach 0.85-0.92
-          - Maximum operating altitude: 15,000 meters
-          - Range with maximum payload: 12,000 kilometers
-
-          ### 2.3 Market Positioning
-
-          The AMPEL360XWLRGA is positioned as a flagship long-range aircraft that demonstrates the viability of zero-emission aviation at scale. It targets the premium long-haul market segment while establishing new standards for environmental performance in commercial aviation.
-
-          ## 3. General Characteristics and Specifications
-
-          ### 3.1 Aircraft Configuration
-
-          The AMPEL360XWLRGA features a wide-body, twin-aisle configuration with the following key characteristics:
-
-          - **Fuselage**: Extended wide-body design with optimized aerodynamics
-          - **Wings**: High-aspect ratio composite wings with advanced aerodynamic features
-          - **Empennage**: Conventional tail configuration with composite structures
-          - **Landing Gear**: Retractable tricycle configuration with multi-wheel bogies
-          - **Propulsion**: Hybrid system combining hydrogen fuel cells, quantum propulsion, and advanced energy harvesting
-
-          ### 3.2 Dimensions
-
-          | Parameter | Value | Units |
-          |-----------|-------|-------|
-          | Overall Length | 73.8 | meters |
-          | Wingspan | 68.5 | meters |
-          | Height | 19.4 | meters |
-          | Cabin Width (interior) | 5.96 | meters |
-          | Cabin Length | 55.7 | meters |
-          | Cabin Height | 2.55 | meters |
-
-          ### 3.3 Weights
-
-          | Parameter | Value | Units |
-          |-----------|-------|-------|
-          | Maximum Takeoff Weight (MTOW) | 280,000 | kg |
-          | Maximum Landing Weight (MLW) | 223,000 | kg |
-          | Maximum Zero Fuel Weight (MZFW) | 195,000 | kg |
-          | Operating Empty Weight (OEW) | 138,000 | kg |
-          | Maximum Payload | 57,000 | kg |
-          | Maximum Fuel Capacity | 85,000 | kg |
-
-          ### 3.4 Performance
-
-          | Parameter | Value | Units |
-          |-----------|-------|-------|
-          | Maximum Range | 12,000 | km |
-          | Cruise Speed | 945 | km/h |
-          | Maximum Operating Mach Number (MMO) | 0.92 | Mach |
-          | Service Ceiling | 15,000 | meters |
-          | Takeoff Field Length (MTOW, SL, ISA) | 2,850 | meters |
-          | Landing Field Length (MLW, SL, ISA) | 1,800 | meters |
-          | Maximum Operating Altitude | 15,000 | meters |
-
-          ### 3.5 Capacity
-
-          | Configuration | Passengers | Class Distribution |
-          |---------------|------------|-------------------|
-          | Three-class | 350 | 40 First, 60 Business, 250 Economy |
-          | Two-class | 410 | 60 Business, 350 Economy |
-          | Single-class | 480 | All Economy |
-          | Cargo | 57,000 kg | Full cargo configuration |
-
-          ## 4. Design Philosophy and Innovation Areas
-
-          ### 4.1 Design Philosophy
-
-          The AMPEL360XWLRGA embodies the following design principles:
-
-          - **Zero Emissions**: Elimination of direct carbon emissions through innovative propulsion
-          - **Sustainability**: Use of sustainable materials and manufacturing processes
-          - **Safety**: Uncompromising approach to safety through redundancy and fail-safe design
-          - **Efficiency**: Optimization of energy use across all aircraft systems
-          - **Passenger Experience**: Enhanced comfort, space, and amenities
-          - **Operational Flexibility**: Adaptability to various route structures and mission profiles
-          - **Future-Proof Design**: Accommodation of technology evolution through modular systems
-
-          ### 4.2 Key Innovation Areas
-
-          #### 4.2.1 Propulsion Systems
-
-          The aircraft features a revolutionary multi-modal propulsion system:
-
-          - **Primary**: Q-01 Quantum Entanglement Engine (QEE) with Cryogenic Cooling System
-          - **Secondary**: Hydrogen fuel cell electric propulsion
-          - **Tertiary**: Advanced Energy Harvesting and Conversion System (AEHCS)
-
-          #### 4.2.2 Materials and Structures
-
-          - Advanced carbon-nanotube reinforced composites
-          - Self-healing structural materials
-          - Biomimetic design principles for weight optimization
-          - Integrated structural health monitoring
-
-          #### 4.2.3 Aerodynamics
-
-          - Active flow control surfaces
-          - Morphing wing technology
-          - Boundary layer ingestion propulsion integration
-          - Laminar flow optimization
-
-          #### 4.2.4 Systems Integration
-
-          - Comprehensive Operational and Functional Integration (COAFI) framework
-          - Distributed electrical architecture
-          - Quantum-secured communications
-          - Advanced sensor fusion and data analytics
-
-          #### 4.2.5 Passenger Experience
-
-          - Customizable cabin environments
-          - Enhanced pressurization (equivalent to 1,500m altitude)
-          - Active noise cancellation
-          - Immersive entertainment systems
-          - Biometric passenger flow management
-
-          ## 5. Operational Concept
-
-          ### 5.1 Normal Operations
-
-          The AMPEL360XWLRGA is designed for conventional airline operations with enhanced capabilities:
-
-          - Standard airport infrastructure compatibility
-          - Reduced turnaround times through optimized systems
-          - Enhanced dispatch reliability through redundant systems
-          - Simplified maintenance procedures
-          - Reduced crew workload through automation
-
-          ### 5.2 Ground Operations
-
-          - Automated pre-flight checks
-          - Integrated ground support equipment interfaces
-          - Rapid hydrogen refueling capability
-          - Quantum propulsion system ground servicing
-          - Enhanced baggage and cargo handling
-
-          ### 5.3 Flight Operations
-
-          - Optimized flight profiles for energy efficiency
-          - Automated energy management
-          - Enhanced navigation precision
-          - Reduced weather sensitivity
-          - Extended operational envelope
-
-          ### 5.4 Maintenance Concept
-
-          - Condition-based maintenance approach
-          - Integrated health monitoring systems
-          - Predictive maintenance capabilities
-          - Modular design for rapid component replacement
-          - Remote diagnostics and troubleshooting
-
-          ## 6. Documentation Schema and Navigation
-
-          ### 6.1 Documentation Structure
-
-          The AMPEL360XWLRGA documentation follows the ATA chapter system with adaptations for novel technologies. This document (GP-AM-AMPEL-0100-00-001-A) serves as the entry point to the complete documentation set.
-
-          ### 6.2 Supporting Documents
-
-          The following key documents provide additional detail on the general aircraft system:
-
-          - **GP-AM-EDR-00-001-SDD-A**: Overall Aircraft System Description Document
-            - Provides detailed system-level description of the entire aircraft
-            - Serves as the primary reference for understanding the aircraft's architecture
-
-          - **GP-AM-EDR-00-002-OV-A**: COAFI Framework Overview for Part I
-            - Outlines the Comprehensive Operational and Functional Integration framework
-            - Explains the methodology for system integration
-
-          - **GP-AM-EDR-00-003-RPT-A**: Airworthiness & Certification Requirements Report
-            - Documents the certification basis and airworthiness requirements
-            - Addresses the unique challenges of certifying novel technologies
-
-          ### 6.3 Cross-References to Other ATA Chapters
-
-          For detailed information on specific aircraft systems, refer to the following ATA chapters within the documentation suite (referencing the master index JSON `COAFI-P1-AMPEL360-0001-A.json` for specific DMCs):
-
-          - **ATA 05-12**: General aircraft documentation (Maintenance Programs, Dimensions, Servicing, etc.)
-          - **ATA 20-49**: Aircraft systems (ECS, Autoflight, Comms, Power, Controls, Fuel, Hydraulics, Nav, CMS, etc.)
-          - **ATA 51-57**: Structures (Fuselage, Wings, Doors, Stabilizers, etc.)
-          - **ATA 71-80**: Power plant (Installation, Engine Core, Controls, Indicating, etc., adapted for Q-01)
-          - **ATA 91-100**: Charts, Wiring, Certification, etc.
-
-          *(Note: The following sections provide direct links to specific key documents within selected ATA chapters for convenience. The complete list resides in the master JSON index.)*
-
-          ### 6.4 ATA 07 – Lifting, Shoring, and Related Procedures
-
-          #### **GP-AM-AMPEL-0100-07-001-A: Lifting Procedures and Diagrams (ATA 07)**
-          - **Document Link:** `GPAM-AMPEL-0201-07-001-A` (DMC: `DMC-GAIAPULSE-AMPEL-0201-07-001-A-001-00_EN-US`)
-          - **Document Type:** Maintenance Procedure
-          - **Content:** Detailed steps for aircraft lifting using specified points and equipment. Includes safety precautions.
-
-          #### **GP-AM-AMPEL-0100-07-002-A: Shoring Procedures and Diagrams (ATA 07)**
-          - **Document Link:** `GPAM-AMPEL-0201-07-002-A` (DMC: `DMC-GAIAPULSE-AMPEL-0201-07-002-A-001-00_EN-US`)
-          - **Document Type:** Maintenance Procedure
-          - **Content:** Procedures for supporting the aircraft structure during maintenance activities, including shoring point diagrams.
-
-          ### 6.5 ATA 08 – Leveling and Weighing
-
-          #### **GP-AM-AMPEL-0100-08-001-A: Leveling Procedures (ATA 08)**
-          - **Document Link:** `GPAM-AMPEL-0201-08-001-A` (DMC: `DMC-GAIAPULSE-AMPEL-0201-08-001-A-001-00_EN-US`)
-          - **Document Type:** Maintenance Procedure
-          - **Content:** Instructions for leveling the aircraft for maintenance or weighing.
-
-          #### **GP-AM-AMPEL-0100-08-002-A: Weighing Procedures (ATA 08)**
-          - **Document Link:** `GPAM-AMPEL-0201-08-002-A` (DMC: `DMC-GAIAPULSE-AMPEL-0201-08-002-A-001-00_EN-US`)
-          - **Document Type:** Maintenance Procedure
-          - **Content:** Procedures for accurately weighing the aircraft to determine weight and balance.
-
-          ### 6.6 ATA 09 – Towing and Taxiing
-
-          #### **GP-AM-AMPEL-0100-09-001-A: Towing Procedures (ATA 09)**
-          - **Document Link:** `GPAM-AMPEL-0201-09-001-A` (DMC: `DMC-GAIAPULSE-AMPEL-0201-09-001-A-001-00_EN-US`)
-          - **Document Type:** Operational Procedure
-          - **Content:** Ground handling procedures for towing the aircraft, including tow bar connections and limitations.
-
-          #### **GP-AM-AMPEL-0100-09-002-A: Taxiing Procedures (ATA 09)**
-          - **Document Link:** `GPAM-AMPEL-0201-09-002-A` (DMC: `DMC-GAIAPULSE-AMPEL-0201-09-002-A-001-00_EN-US`)
-          - **Document Type:** Operational Procedure
-          - **Content:** Standard operating procedures for taxiing the aircraft under its own power.
-
-          ### 6.7 ATA 10 – Parking, Mooring, Storage, and Return to Service
-
-          #### **GP-AM-AMPEL-0100-10-001-A: Parking Procedures (ATA 10)**
-          - **Document Link:** `GPAM-AMPEL-0201-10-001-A` (DMC: `DMC-GAIAPULSE-AMPEL-0201-10-001-A-001-00_EN-US`)
-          - **Document Type:** Operational Procedure
-          - **Content:** Procedures for parking the aircraft, including brake setting and chocking.
-
-          #### **GP-AM-AMPEL-0100-10-002-A: Mooring Procedures (ATA 10)**
-          - **Document Link:** `GPAM-AMPEL-0201-10-002-A` (DMC: `DMC-GAIAPULSE-AMPEL-0201-10-002-A-001-00_EN-US`)
-          - **Document Type:** Operational Procedure
-          - **Content:** Instructions for securing the aircraft in high-wind conditions or during extended parking.
-
-          #### **GP-AM-AMPEL-0100-10-003-A: Storage Procedures (ATA 10)**
-          - **Document Link:** `GPAM-AMPEL-0201-10-003-A` (DMC: `DMC-GAIAPULSE-AMPEL-0201-10-003-A-001-00_EN-US`)
-          - **Document Type:** Operational Procedure / Maintenance Procedure
-          - **Content:** Procedures for preparing and maintaining the aircraft during short-term or long-term storage.
-
-          #### **GP-AM-AMPEL-0100-10-004-A: Return to Service Procedures (ATA 10)**
-          - **Document Link:** `GPAM-AMPEL-0201-10-004-A` (DMC: `DMC-GAIAPULSE-AMPEL-0201-10-004-A-001-00_EN-US`)
-          - **Document Type:** Maintenance Procedure
-          - **Content:** Steps required to de-preserve and prepare the aircraft for operational service after storage.
-
-          ### 6.8 ATA 11 – Placards and Markings
-
-          #### **GP-AM-AMPEL-0100-11-001-A: Exterior Placard Locations (ATA 11)**
-          - **Document Link:** `GPAM-AMPEL-0201-11-001-A` (DMC: `DMC-GAIAPULSE-AMPEL-0201-11-001-A-001-00_EN-US`)
-          - **Document Type:** Technical Drawing / Data
-          - **Content:** Diagrams showing the location and content of all required exterior placards.
-
-          #### **GP-AM-AMPEL-0100-11-002-A: Interior Placard Locations (ATA 11)**
-          - **Document Link:** `GPAM-AMPEL-0201-11-002-A` (DMC: `DMC-GAIAPULSE-AMPEL-0201-11-002-A-001-00_EN-US`)
-          - **Document Type:** Technical Drawing / Data
-          - **Content:** Diagrams showing the location and content of all required interior (cockpit and cabin) placards.
-
-          #### **GP-AM-AMPEL-0100-11-003-A: Marking Specifications (ATA 11)**
-          - **Document Link:** `GPAM-AMPEL-0201-11-003-A` (DMC: `DMC-GAIAPULSE-AMPEL-0201-11-003-A-001-00_EN-US`)
-          - **Document Type:** Technical Specification
-          - **Content:** Specifications for aircraft livery, mandatory markings, materials, and application methods.
-
-          ### 6.9 ATA 12 – Servicing
-
-          #### **GP-AM-AMPEL-0100-12-001-A: Fluid Servicing Procedures (ATA 12)**
-          - **Document Link:** `GPAM-AMPEL-0201-12-001-A` (DMC: `DMC-GAIAPULSE-AMPEL-0201-12-001-A-001-00_EN-US`)
-          - **Document Type:** Maintenance Procedure
-          - **Content:** Procedures for servicing hydraulic fluid, engine oil/coolant (adapted for Q-01), etc.
-
-          #### **GP-AM-AMPEL-0100-12-002-A: Nitrogen/Oxygen Servicing Procedures (ATA 12)**
-          - **Document Link:** `GPAM-AMPEL-0201-12-002-A` (DMC: `DMC-GAIAPULSE-AMPEL-0201-12-002-A-001-00_EN-US`)
-          - **Document Type:** Maintenance Procedure
-          - **Content:** Procedures for servicing high-pressure nitrogen (e.g., landing gear struts) and oxygen systems.
-
-          #### **GP-AM-AMPEL-0100-12-003-A: Lubrication Procedures (ATA 12)**
-          - **Document Link:** `GPAM-AMPEL-0201-12-003-A` (DMC: `DMC-GAIAPULSE-AMPEL-0201-12-003-A-001-00_EN-US`)
-          - **Document Type:** Maintenance Procedure
-          - **Content:** Detailed lubrication schedule and procedures for various aircraft components.
-
-          #### **GP-AM-AMPEL-0100-12-004-A: Water Servicing Procedures (ATA 12)**
-          - **Document Link:** `GPAM-AMPEL-0201-12-004-A` (DMC: `DMC-GAIAPULSE-AMPEL-0201-12-004-A-001-00_EN-US`)
-          - **Document Type:** Maintenance Procedure
-          - **Content:** Procedures for servicing the potable water system and waste system (rinse/flush).
-
-          ### 6.10 ATA 18 – Vibration and Noise Analysis
-
-          #### **GP-AM-AMPEL-0100-18-001-A: Vibration Analysis Procedures (ATA 18)**
-          - **Document Link:** `GPAM-AMPEL-0201-18-001-A` (DMC: `DMC-GAIAPULSE-AMPEL-0201-18-001-A-001-00_EN-US`)
-          - **Document Type:** Maintenance Procedure / Diagnostic
-          - **Content:** Procedures for collecting and analyzing vibration data from engines (Q-01), APU, and rotating machinery.
-
-          #### **GP-AM-AMPEL-0100-18-002-A: Noise Level Measurement Procedures (ATA 18)**
-          - **Document Link:** `GPAM-AMPEL-0201-18-002-A` (DMC: `DMC-GAIAPULSE-AMPEL-0201-18-002-A-001-00_EN-US`)
-          - **Document Type:** Maintenance Procedure / Test
-          - **Content:** Procedures for measuring exterior and interior noise levels for certification and troubleshooting.
-
-          #### **GP-AM-AMPEL-0100-18-003-A: Vibration and Noise Limits and Acceptability Criteria (ATA 18)**
-          - **Document Link:** `GPAM-AMPEL-0201-18-003-A` (DMC: `DMC-GAIAPULSE-AMPEL-0201-18-003-A-001-00_EN-US`)
-          - **Document Type:** Technical Specification / Data
-          - **Content:** Specifies the acceptable limits for vibration and noise levels during various operational phases.
-
-          ### 6.11 ATA 20 – Standard Practices - Airframe
-
-          #### **GP-AM-AMPEL-0100-20-001-A: Airframe Standard Practices Manual (ATA 20)**
-          - **Document Link:** `GPAM-AMPEL-0201-20-001-A` (DMC: `DMC-GAIAPULSE-AMPEL-0201-20-001-A-001-00_EN-US`)
-          - **Document Type:** Maintenance Manual / Standard
-          - **Content:** General procedures, techniques, and standards for airframe maintenance (e.g., fastener installation, sealing, composite repair basics).
-
-          #### **GP-AM-AMPEL-0100-20-002-A: Corrosion Prevention and Control Program (CPCP)**
-          - **Document Link:** `GPAM-AMPEL-0201-20-002-A` (DMC: `DMC-GAIAPULSE-AMPEL-0201-20-002-A-001-00_EN-US`)
-          - **Document Type:** Maintenance Program / Plan
-          - **Content:** Outlines the program for preventing and controlling corrosion on the aircraft structure.
-
-          #### **GP-AM-AMPEL-0100-20-003-A: Non-Destructive Testing (NDT) Manual**
-          - **Document Link:** `GPAM-AMPEL-0201-20-003-A` (DMC: `DMC-GAIAPULSE-AMPEL-0201-20-003-A-001-00_EN-US`)
-          - **Document Type:** Maintenance Procedure / Manual
-          - **Content:** Specific procedures for various NDT methods (ultrasonic, eddy current, radiography, etc.) applicable to the aircraft structure.
-
-          ### 6.12 ATA 21 – Air Conditioning and Pressurization
-
-          #### **GP-AM-AMPEL-0100-21-001-A: Air Conditioning System Description and Operation (ATA 21)**
-          - **Document Link:** `GPAM-AMPEL-0201-21-001-A` (DMC: `DMC-GAIAPULSE-AMPEL-0201-21-001-A-001-00_EN-US`)
-          - **Document Type:** System Description (SDD)
-          - **Content:** Detailed description of the air conditioning packs, distribution, and temperature control.
-
-          #### **GP-AM-AMPEL-0100-21-002-A: Pressurization System Description and Operation (ATA 21)**
-          - **Document Link:** `GPAM-AMPEL-0201-21-002-A` (DMC: `DMC-GAIAPULSE-AMPEL-0201-21-002-A-001-00_EN-US`)
-          - **Document Type:** System Description (SDD)
-          - **Content:** Detailed description of the cabin pressure control system, including outflow valves and controllers.
-
-          #### **GP-AM-AMPEL-0100-21-003-A: Quantum Enhanced Air Purification System (QE-APS) Description (ATA 21)**
-          - **Document Link:** `GPAM-AMPEL-0201-21-003-A` (DMC: `DMC-GAIAPULSE-AMPEL-0201-21-003-A-001-00_EN-US`)
-          - **Document Type:** System Description (SDD) / Technical Specification
-          - **Content:** Description of the novel QE-APS technology for air filtration and revitalization.
-
-          ### 6.13 ATA 22 – Autoflight
-
-          #### **GP-AM-AMPEL-0100-22-001-A: Autopilot System Description and Operation (ATA 22)**
-          - **Document Link:** `GPAM-AMPEL-0201-22-001-A` (DMC: `DMC-GAIAPULSE-AMPEL-0201-22-001-A-001-00_EN-US`)
-          - **Document Type:** System Description (SDD)
-          - **Content:** Description of the autopilot modes, flight director, and servo control systems.
-
-          #### **GP-AM-AMPEL-0100-22-002-A: Flight Management System (FMS) Description and Operation (ATA 22)**
-          - **Document Link:** `GPAM-AMPEL-0201-22-002-A` (DMC: `DMC-GAIAPULSE-AMPEL-0201-22-002-A-001-00_EN-US`)
-          - **Document Type:** System Description (SDD) / Operational Manual
-          - **Content:** Description of FMS capabilities, database structure, flight planning, and performance management.
-
-          #### **GP-AM-AMPEL-0100-22-003-A: AI-Enhanced Flight Control System (AI-FCS) Description (ATA 22)**
-          - **Document Link:** `GPAM-AMPEL-0201-22-003-A` (DMC: `DMC-GAIAPULSE-AMPEL-0201-22-003-A-001-00_EN-US`)
-          - **Document Type:** System Description (SDD) / Technical Specification
-          - **Content:** Description of the AI algorithms (OIP, Heuristics), learning capabilities, and integration with conventional autoflight.
-
-          ### 6.14 ATA 23 – Communications
-
-          #### **GP-AM-AMPEL-0100-23-001-A: Communication Systems Overview (ATA 23)**
-          - **Document Link:** `GPAM-AMPEL-0201-23-001-A` (DMC: `DMC-GAIAPULSE-AMPEL-0201-23-001-A-001-00_EN-US`)
-          - **Document Type:** System Overview / Architecture
-          - **Content:** High-level overview of all communication systems (VHF, HF, SATCOM, Datalink, QCS) and their interactions.
-
-          #### **GP-AM-AMPEL-0100-23-002-A: Satellite Communication (SATCOM) System Description and Operation (ATA 23)**
-          - **Document Link:** `GPAM-AMPEL-0201-23-002-A` (DMC: `DMC-GAIAPULSE-AMPEL-0201-23-002-A-001-00_EN-US`)
-          - **Document Type:** System Description (SDD)
-          - **Content:** Detailed description of the SATCOM equipment, antenna, network providers, and capabilities.
-
-          #### **GP-AM-AMPEL-0100-23-003-A: Air-to-Ground Communication System Description and Operation (ATA 23)**
-          - **Document Link:** `GPAM-AMPEL-0201-23-003-A` (DMC: `DMC-GAIAPULSE-AMPEL-0201-23-003-A-001-00_EN-US`)
-          - **Document Type:** System Description (SDD)
-          - **Content:** Description of VHF/HF voice and data communication systems, ACARS, etc.
-
-          #### **GP-AM-AMPEL-0100-23-004-A: Quantum Communication System (QCS) Description (ATA 23)**
-          - **Document Link:** `GPAM-AMPEL-0201-23-004-A` (DMC: `DMC-GAIAPULSE-AMPEL-0201-23-004-A-001-00_EN-US`)
-          - **Document Type:** System Description (SDD) / Technical Specification
-          - **Content:** Description of the quantum communication hardware, protocols (potentially QKD), and integration for secure data links.
-
-          ### 6.15 ATA 24 – Electrical Power
-
-          #### **GP-AM-AMPEL-0100-24-001-A: Electrical Power Generation System Description and Operation (ATA 24)**
-          - **Document Link:** `GPAM-AMPEL-0201-24-001-A` (DMC: `DMC-GAIAPULSE-AMPEL-0201-24-001-A-001-00_EN-US`)
-          - **Document Type:** System Description (SDD)
-          - **Content:** Description of primary power generation sources (AEHCS, Fuel Cells, Q-01 bleed if any) and control.
-
-          #### **GP-AM-AMPEL-0100-24-002-A: Electrical Power Distribution System Description and Operation (ATA 24)**
-          - **Document Link:** `GPAM-AMPEL-0201-24-002-A` (DMC: `DMC-GAIAPULSE-AMPEL-0201-24-002-A-001-00_EN-US`)
-          - **Document Type:** System Description (SDD)
-          - **Content:** Description of the HVDC/LVDC architecture, bus bars, circuit breakers, contactors, and wiring philosophy.
-
-          #### **GP-AM-AMPEL-0100-24-003-A: Quantum Energy Management System (Q-EMS / AAESCCCTS) Description (ATA 24)**
-          - **Document Link:** `GPAM-AMPEL-0201-24-003-A` (DMC: `DMC-GAIAPULSE-AMPEL-0201-24-003-A-001-00_EN-US`) / `AGIS-MOD-AAESCCCTS-01`
-          - **Document Type:** System Description (SDD) / Module Specification
-          - **Content:** Description of energy storage (Quantum Batteries), power conversion, intelligent load management, and integration with MOD-XAI/QUAD.
-
-          ### 6.16 ATA 25 – Equipment / Furnishings
-
-          #### **GP-AM-AMPEL-0100-25-001-A: Flight Deck Equipment and Furnishings (ATA 25)**
-          - **Document Link:** `GPAM-AMPEL-0201-25-001-A` (DMC: `DMC-GAIAPULSE-AMPEL-0201-25-001-A-001-00_EN-US`)
-          - **Document Type:** System Description / Drawing Set
-          - **Content:** Layout, specifications, and part numbers for cockpit seats, panels, controls integration, etc.
-
-          #### **GP-AM-AMPEL-0100-25-002-A: Cabin Equipment and Furnishings (ATA 25)**
-          - **Document Link:** `GPAM-AMPEL-0201-25-002-A` (DMC: `DMC-GAIAPULSE-AMPEL-0201-25-002-A-001-00_EN-US`)
-          - **Document Type:** System Description / Drawing Set / Catalog
-          - **Content:** Layout, specifications for passenger seats, galleys, lavatories, overhead bins, lighting integration, IFE hardware.
-
-          #### **GP-AM-AMPEL-0100-25-003-A: Emergency Equipment (ATA 25)**
-          - **Document Link:** `GPAM-AMPEL-0201-25-003-A` (DMC: `DMC-GAIAPULSE-AMPEL-0201-25-003-A-001-00_EN-US`)
-          - **Document Type:** System Description / Data
-          - **Content:** Location, description, and maintenance requirements for emergency equipment (slides, rafts, first aid kits, fire extinguishers, ELTs).
-
-          ### 6.17 ATA 26 – Fire Protection
-
-          #### **GP-AM-AMPEL-0100-26-001-A: Fire Detection System Description and Operation (ATA 26)**
-          - **Document Link:** `GP
-          EOL
-
-      - name: Create GitHub Issue for Capgemini Spain
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const issueTitle = "New Organization Registration Request: Capgemini Spain";
-            const issueBody = `
-### **New Organization Registration Request: Capgemini Spain**
-
-#### **Name of the organization**
-**Capgemini Spain**
-
----
-
-#### **Official website**
-https://www.capgemini.com/es-es/
-
----
-
-#### **Country**
-**Spain**
-
----
-
-#### **City**
-**Madrid**
-
----
-
-#### **Type of organization**
-- **Engineering**
-- **Research Organization**
-- **Company**
-- **Consulting Firm**
-
-(*Multi-type classification suggested based on active engagement in engineering R&D, software development, and scientific projects*)
-
----
-
-#### **Parent organization**
-**Capgemini SE**  
-ROR: https://ror.org/01bjdm005
-
----
-
-#### **Description / Purpose**
-Capgemini Spain is the Spanish operational and legal branch of Capgemini SE, a global leader in technology, engineering, and consulting services. It spearheads initiatives in AI, aerospace systems, quantum computing, sustainability, and digital engineering.
-
-Capgemini Spain is deeply engaged in:
-- Engineering-intensive projects across the EU and nationally
-- Strategic partnerships in aviation, defense, and space technology
-- Research platforms involving AI, federated systems, and data ethics
-
-It contributes to both industrial innovation and scientific reproducibility via ORCID-linked outputs, project documentation, and open science platforms.
-
----
-
-#### **Justification for separate ROR ID**
-Capgemini Spain:
-- Operates as a legal and fiscal entity distinct from the parent company
-- Leads engineering and scientific research initiatives with Spanish and EU institutions
-- Has identifiable staff contributing to ORCID-registered publications and replicable projects
-- Requires clear attribution in systems like GAIA AIR, Zenodo, ORCID, DataCite, and national R&D repositories
-
-A separate ROR ID would ensure proper affiliation tracking, reproducibility auditing, and funding traceability.
-
----
-
-#### **Additional supporting links**
-- ORCID: Amedeo Pelliccia – Capgemini Spain
-- Capgemini Spain – Engineering & Innovation
-- GAIA AIR Engineering Contributor Node
-- Capgemini España S.L. – Legal Info
-
----
-
-Puedes copiar y pegar esta plantilla en un nuevo Issue en el repositorio de ROR en GitHub. Si necesitas ayuda adicional para crear el Issue o cualquier otra cosa, ¡solo dímelo! 😊
-            `;
-
-            const { data: issue } = await github.issues.create({
-              owner: 'ROR',
-              repo: 'ROR',
-              title: issueTitle,
-              body: issueBody,
-            });
-
-            core.info(`Created issue: ${issue.html_url}`);
+          mkdir -p docs/GP-AM/01
+          mkdir -p docs/GP-AM/02
+          mkdir -p docs/GP-AM/03
+          mkdir -p docs/GP-AM/04
+          mkdir -p docs/GP-AM/05
+          mkdir -p docs/GP-AM/06
+          mkdir -p docs/GP-AM/07
+          mkdir -p docs/GP-AM/08
+          mkdir -p docs/GP-AM/09
+          mkdir -p docs/GP-AM/10
+          mkdir -p docs/GP-AM/11
+          mkdir -p docs/GP-AM/12
+          mkdir -p docs/GP-AM/13
+          mkdir -p docs/GP-AM/14
+          mkdir -p docs/GP-AM/15
+          mkdir -p docs/GP-AM/16
+          mkdir -p docs/GP-AM/17
+          mkdir -p docs/GP-AM/18
+          mkdir -p docs/GP-AM/19
+          mkdir -p docs/GP-AM/20
+          mkdir -p docs/GP-AM/21
+          mkdir -p docs/GP-AM/22
+          mkdir -p docs/GP-AM/23
+          mkdir -p docs/GP-AM/24
+          mkdir -p docs/GP-AM/25
+          mkdir -p docs/GP-AM/26
+          mkdir -p docs/GP-AM/27
+          mkdir -p docs/GP-AM/28
+          mkdir -p docs/GP-AM/29
+          mkdir -p docs/GP-AM/30
+          mkdir -p docs/GP-AM/31
+          mkdir -p docs/GP-AM/32
+          mkdir -p docs/GP-AM/33
+          mkdir -p docs/GP-AM/34
+          mkdir -p docs/GP-AM/35
+          mkdir -p docs/GP-AM/36
+          mkdir -p docs/GP-AM/37
+          mkdir -p docs/GP-AM/38
+          mkdir -p docs/GP-AM/39
+          mkdir -p docs/GP-AM/40
+          mkdir -p docs/GP-AM/41
+          mkdir -p docs/GP-AM/42
+          mkdir -p docs/GP-AM/43
+          mkdir -p docs/GP-AM/44
+          mkdir -p docs/GP-AM/45
+          mkdir -p docs/GP-AM/46
+          mkdir -p docs/GP-AM/47
+          mkdir -p docs/GP-AM/48
+          mkdir -p docs/GP-AM/49
+          mkdir -p docs/GP-AM/50
+          mkdir -p docs/GP-AM/51
+          mkdir -p docs/GP-AM/52
+          mkdir -p docs/GP-AM/53
+          mkdir -p docs/GP-AM/54
+          mkdir -p docs/GP-AM/55
+          mkdir -p docs/GP-AM/56
+          mkdir -p docs/GP-AM/57
+          mkdir -p docs/GP-AM/58
+          mkdir -p docs/GP-AM/59
+          mkdir -p docs/GP-AM/60
+          mkdir -p docs/GP-AM/61
+          mkdir -p docs/GP-AM/62
+          mkdir -p docs/GP-AM/63
+          mkdir -p docs/GP-AM/64
+          mkdir -p docs/GP-AM/65
+          mkdir -p docs/GP-AM/66
+          mkdir -p docs/GP-AM/67
+          mkdir -p docs/GP-AM/68
+          mkdir -p docs/GP-AM/69
+          mkdir -p docs/GP-AM/70
+          mkdir -p docs/GP-AM/71
+          mkdir -p docs/GP-AM/72
+          mkdir -p docs/GP-AM/73
+          mkdir -p docs/GP-AM/74
+          mkdir -p docs/GP-AM/75
+          mkdir -p docs/GP-AM/76
+          mkdir -p docs/GP-AM/77
+          mkdir -p docs/GP-AM/78
+          mkdir -p docs/GP-AM/79
+          mkdir -p docs/GP-AM/80
+          mkdir -p docs/GP-AM/81
+          mkdir -p docs/GP-AM/82
+          mkdir -p docs/GP-AM/83
+          mkdir -p docs/GP-AM/84
+          mkdir -p docs/GP-AM/85
+          mkdir -p docs/GP-AM/86
+          mkdir -p docs/GP-AM/87
+          mkdir -p docs/GP-AM/88
+          mkdir -p docs/GP-AM/89
+          mkdir -p docs/GP-AM/90
+          mkdir -p docs/GP-AM/91
+          mkdir -p docs/GP-AM/92
+          mkdir -p docs/GP-AM/93
+          mkdir -p docs/GP-AM/94
+          mkdir -p docs/GP-AM/95
+          mkdir -p docs/GP-AM/96
+          mkdir -p docs/GP-AM/97
+          mkdir -p docs/GP-AM/98
+          mkdir -p docs/GP-AM/99
+          mkdir -p docs/GP-AS/10
+          mkdir -p docs/GP-AS/20
+          mkdir -p docs/GP-AS/30
+          mkdir -p docs/GP-AS/40
+          mkdir -p docs/GP-AS/50
+          mkdir -p docs/GP-AS/60
+          mkdir -p docs/GP-AS/70
+          mkdir -p docs/GP-AS/80
+          mkdir -p docs/GP-AS/90

--- a/docs/air/00/index.md
+++ b/docs/air/00/index.md
@@ -1,0 +1,105 @@
+# GAIA AIR Documentation
+
+## ATA 00 — General (Air-Specific Aspects)
+
+> **Document ID:** GAIA-AIR-00-00-Index-IDX-A   |   **Revision:** 0.3   |   **Date:** 2025-05-05   |   **Status:** DRAFT
+
+---
+
+### Deep Dive into ATA 00 — General (Air‑Specific Aspects)
+
+This chapter serves as the **foundation** for shared aircraft‑wide principles in GAIA AIR. It establishes common terminology, regulatory standards, and structural guidelines inherited by downstream ATA chapters.
+
+---
+
+## 1 · Purpose & Scope
+
+ATA 00 is **not** tied to a single aircraft system; it provides the overarching framework for documentation, regulatory compliance, and program‑level coordination.
+
+* ✔ Standardizes **definitions and abbreviations** for subsystem interoperability.
+* ✔ Hosts **regulatory references** that cut across multiple domains.
+* ✔ Defines **core conventions** for GAIA AIR documentation, metadata, and AI‑driven enhancements.
+* ✔ Aligns the program with **Industry 5.0 and sustainability initiatives**.
+
+---
+
+## 2 · Key Sections & Their Functions
+
+The document structure follows GAIA AIR’s modular indexing system. Each section plays a distinct role:
+
+| Section   | Title                                           | Function                                                                        |
+| --------- | ----------------------------------------------- | ------------------------------------------------------------------------------- |
+| **00‑10** | Definitions & Abbreviations                     | Acronyms, terms, and interoperability standards shared across the program.      |
+| **00‑20** | Regulatory References & Certifications          | Compliance frameworks (EASA, FAA, ICAO), approval workflows.                    |
+| **00‑30** | Program Applicability & Configuration Baselines | Applicability matrix and cross‑platform compatibility criteria.                 |
+| **00‑40** | Document Conventions & Metadata                 | GAIA‑CO‑ASD‑LIB metadata block, content tagging, AI indexing rules.             |
+| **00‑50** | Safety & Ethical Framework Overview             | Risk models, ethical guidelines, human‑centered AI considerations.              |
+| **00‑60** | Industry 5.0 & Sustainability Alignment         | Eco‑friendly manufacturing, carbon‑footprint reduction, predictive maintenance. |
+
+---
+
+## Document Inventory (ATA 00 Files)
+
+| Document ID                                   | Title                                 | Type                       | Status |
+| --------------------------------------------- | ------------------------------------- | -------------------------- | ------ |
+| GAIA-AIR-00-00-00-General-OV-A.md             | ATA 00 – General Information Overview | Overview                   | DRAFT  |
+| GAIA-AIR-00-00-001-GeneralSpecs-SPEC-A.yaml   | General Specifications                | Specification              | DRAFT  |
+| GAIA-AIR-00-00-002-Glossary-GLO-A.md          | GAIA AIR Glossary                     | Glossary                   | DRAFT  |
+| GAIA-AIR-00-10-001-ReqMgmt-SPEC-A.yaml        | Requirements Management Framework     | Specification              | DRAFT  |
+| GAIA-AIR-00-20-001-StdPractices-PROC-A.md     | Standard Practices – Airframe         | Procedure                  | DRAFT  |
+| GAIA-AIR-00-30-001-AircraftDim-DWG-A.svg      | Aircraft Dimensions and Areas         | Drawing                    | DRAFT  |
+| GAIA-AIR-00-40-001-LiftingProc-PROC-A.md      | Aircraft Lifting Procedures           | Procedure                  | DRAFT  |
+| GAIA-AIR-00-50-001-WeighingProc-PROC-A.md     | Aircraft Weighing Procedures          | Procedure                  | DRAFT  |
+| GAIA-AIR-00-60-001-GroundHandling-PROC-A.md   | Ground Handling Procedures            | Procedure                  | DRAFT  |
+| GAIA-AIR-00-70-001-EnginePractices-PROC-A.md  | Standard Practices – Engines          | Procedure                  | DRAFT  |
+| GAIA-AIR-00-80-001-SystemsPractices-PROC-A.md | Standard Practices – Systems          | Procedure                  | DRAFT  |
+| GAIA-AIR-00-90-001-Integration-ICD-A.yaml     | GAIA AIR Systems Integration          | Interface Control Document | DRAFT  |
+
+---
+
+## 3 · Metadata & Documentation Standards
+
+To maintain documentation integrity, GAIA AIR employs a **structured metadata convention** ensuring interoperability across digital tools.
+
+**File‑naming standard**
+`[Project]-[Domain]-[Chapter]-[Section]-[Subject]-[InfoCode]-[Variant]`
+
+Example → `GAIA-AIR-00-10-Definitions-GLO-A.md` (General definitions, variant A).
+
+Each file must include the **GAIA‑CO‑ASD‑LIB metadata block** with fields for `title`, `documentID`, `revision`, `date`, `status`, `applicability`, `authors`, and so on.
+
+---
+
+## 4 · AI & Automation Integration
+
+* **AI‑enhanced safety monitoring** for ethical compliance.
+* **Automated regulatory updates** via NLP‑driven certification tracking.
+* **Semantic search embeddings** for fast retrieval of references.
+* **Predictive maintenance analytics** aligned with sustainability goals.
+
+---
+
+## 5 · Revision Control & Future Expansions
+
+Current version **Rev 0.3 (2025-05-05)** — deep‑dive content integrated and document inventory added.
+Pending expert review for regulatory alignment and AI index validation.
+
+---
+
+### Quick Links
+
+* **Master Index:** `../index.md`
+* **Air Domain Root:** `../`
+* **ACE Handbook (Platform‑IA):** `../../ai/handbook/GAIA-PLATFORM-OF-MASTERY-v1.0.md`
+
+### Revision History
+
+| Rev | Date       | Author                | Summary                                          |
+| --- | ---------- | --------------------- | ------------------------------------------------ |
+| 0.3 | 2025-05-05 | GVECGA Assistant (o3) | Added Document Inventory and refined formatting. |
+| 0.2 | 2025-05-05 | GVECGA Assistant (o3) | Added deep‑dive content, section table.          |
+| 0.1 | 2025-05-05 | GVECGA Assistant (o3) | Initial stub creation.                           |
+
+---
+
+© 2025 GAIA Platforms — All Rights Reserved

--- a/docs/air/01/index.md
+++ b/docs/air/01/index.md
@@ -1,0 +1,96 @@
+# GAIA AIR Documentation
+
+## ATA 01 — Aircraft General
+
+> **Document ID:** GAIA-AIR-01-00-Index-IDX-A   |   **Revision:** 0.1   |   **Date:** 2025-05-05   |   **Status:** DRAFT
+
+---
+
+### Overview of ATA 01 — Aircraft General
+
+This chapter provides a comprehensive overview of the general characteristics, design philosophy, and operational concept of the aircraft. It serves as the primary entry point to the complete aircraft documentation and establishes the foundation for all subsequent technical documentation.
+
+---
+
+## 1. Purpose & Scope
+
+ATA 01 covers the general aspects of the aircraft, including its design philosophy, operational concept, and high-level specifications. It provides a holistic view of the aircraft's capabilities and serves as a reference for understanding the overall design and functionality.
+
+* ✔ Establishes the general characteristics and design philosophy of the aircraft.
+* ✔ Provides an overview of the operational concept and mission profile.
+* ✔ Defines the high-level specifications and performance parameters.
+
+---
+
+## 2. Key Sections & Their Functions
+
+The document structure follows GAIA AIR’s modular indexing system. Each section plays a distinct role:
+
+| Section   | Title                                           | Function                                                                        |
+| --------- | ----------------------------------------------- | ------------------------------------------------------------------------------- |
+| **01-10** | Aircraft General Characteristics                | Overview of the aircraft's general characteristics and specifications.           |
+| **01-20** | Design Philosophy                               | Description of the design philosophy and innovation areas.                      |
+| **01-30** | Operational Concept                             | Overview of the operational concept and mission profile.                        |
+| **01-40** | High-Level Specifications                       | Detailed high-level specifications and performance parameters.                  |
+| **01-50** | Documentation Schema                            | Structure and navigation of the aircraft documentation.                        |
+
+---
+
+## Document Inventory (ATA 01 Files)
+
+| Document ID                                   | Title                                 | Type                       | Status |
+| --------------------------------------------- | ------------------------------------- | -------------------------- | ------ |
+| GAIA-AIR-01-00-00-General-OV-A.md             | ATA 01 – General Information Overview | Overview                   | DRAFT  |
+| GAIA-AIR-01-00-001-GeneralSpecs-SPEC-A.yaml   | General Specifications                | Specification              | DRAFT  |
+| GAIA-AIR-01-00-002-Glossary-GLO-A.md          | GAIA AIR Glossary                     | Glossary                   | DRAFT  |
+| GAIA-AIR-01-10-001-DesignPhilosophy-SPEC-A.yaml | Design Philosophy                     | Specification              | DRAFT  |
+| GAIA-AIR-01-20-001-OperationalConcept-OV-A.md | Operational Concept                   | Overview                   | DRAFT  |
+| GAIA-AIR-01-30-001-HighLevelSpecs-SPEC-A.yaml | High-Level Specifications             | Specification              | DRAFT  |
+| GAIA-AIR-01-40-001-DocumentationSchema-OV-A.md | Documentation Schema                  | Overview                   | DRAFT  |
+
+---
+
+## 3. Metadata & Documentation Standards
+
+To maintain documentation integrity, GAIA AIR employs a **structured metadata convention** ensuring interoperability across digital tools.
+
+**File-naming standard**
+`[Project]-[Domain]-[Chapter]-[Section]-[Subject]-[InfoCode]-[Variant]`
+
+Example → `GAIA-AIR-01-10-DesignPhilosophy-SPEC-A.yaml` (Design philosophy, variant A).
+
+Each file must include the **GAIA-CO-ASD-LIB metadata block** with fields for `title`, `documentID`, `revision`, `date`, `status`, `applicability`, `authors`, and so on.
+
+---
+
+## 4. AI & Automation Integration
+
+* **AI-enhanced safety monitoring** for ethical compliance.
+* **Automated regulatory updates** via NLP-driven certification tracking.
+* **Semantic search embeddings** for fast retrieval of references.
+* **Predictive maintenance analytics** aligned with sustainability goals.
+
+---
+
+## 5. Revision Control & Future Expansions
+
+Current version **Rev 0.1 (2025-05-05)** — initial content added and document structure established.
+Pending expert review for regulatory alignment and AI index validation.
+
+---
+
+### Quick Links
+
+* **Master Index:** `../index.md`
+* **Air Domain Root:** `../`
+* **ACE Handbook (Platform-IA):** `../../ai/handbook/GAIA-PLATFORM-OF-MASTERY-v1.0.md`
+
+### Revision History
+
+| Rev | Date       | Author                | Summary                                          |
+| --- | ---------- | --------------------- | ------------------------------------------------ |
+| 0.1 | 2025-05-05 | GVECGA Assistant (o3) | Initial content added and document structure established. |
+
+---
+
+© 2025 GAIA Platforms — All Rights Reserved

--- a/docs/common/cn/ToC-GP-CN.md
+++ b/docs/common/cn/ToC-GP-CN.md
@@ -1,0 +1,41 @@
+# Computing Networks (GP-CN) - Master Index
+
+This document serves as the master index for the Computing Networks (GP-CN) part of the GAIA Documentation Ecosystem. It provides an organized structure and links to all relevant documents within this part.
+
+## Table of Contents
+
+1. [Data Networks](#data-networks)
+2. [Information Security](#information-security)
+3. [Data Management](#data-management)
+4. [Computing Infrastructure](#computing-infrastructure)
+5. [Core Software/Security/AI Modules](#core-softwaresecurityai-modules)
+
+## 1. Data Networks
+
+- **Document ID:** GP-CN-00-001-OV-A
+- **Title:** Overview of Data Networks
+- **Link:** [GP-CN-00-001-OV-A.md](GP-CN-00-001-OV-A.md)
+
+## 2. Information Security
+
+- **Document ID:** GP-CN-01-001-OV-A
+- **Title:** Overview of Information Security
+- **Link:** [GP-CN-01-001-OV-A.md](GP-CN-01-001-OV-A.md)
+
+## 3. Data Management
+
+- **Document ID:** GP-CN-02-001-OV-A
+- **Title:** Overview of Data Management
+- **Link:** [GP-CN-02-001-OV-A.md](GP-CN-02-001-OV-A.md)
+
+## 4. Computing Infrastructure
+
+- **Document ID:** GP-CN-03-001-OV-A
+- **Title:** Overview of Computing Infrastructure
+- **Link:** [GP-CN-03-001-OV-A.md](GP-CN-03-001-OV-A.md)
+
+## 5. Core Software/Security/AI Modules
+
+- **Document ID:** GP-CN-04-001-OV-A
+- **Title:** Overview of Core Software/Security/AI Modules
+- **Link:** [GP-CN-04-001-OV-A.md](GP-CN-04-001-OV-A.md)

--- a/docs/common/dimensions/ToC-GP-DIMENSIONS.md
+++ b/docs/common/dimensions/ToC-GP-DIMENSIONS.md
@@ -1,0 +1,55 @@
+# Research & Speculation (GP-DIMENSIONS) - Master Index
+
+This document serves as the master index for the Research & Speculation (GP-DIMENSIONS) part of the GAIA Documentation Ecosystem. It provides an organized structure and links to all relevant documents within this part.
+
+## Table of Contents
+
+1. [Futures Introduction](#futures-introduction)
+2. [Propulsion Concepts](#propulsion-concepts)
+3. [Advanced Materials](#advanced-materials)
+4. [Novel Architectures](#novel-architectures)
+5. [Advanced AI/Consciousness](#advanced-aiconsciousness)
+6. [Socio-Economic Futures](#socio-economic-futures)
+7. [Fundamental Physics](#fundamental-physics)
+
+## 1. Futures Introduction
+
+- **Document ID:** GP-DIMENSIONS-00-001-OV-A
+- **Title:** Overview of Futures Introduction
+- **Link:** [GP-DIMENSIONS-00-001-OV-A.md](GP-DIMENSIONS-00-001-OV-A.md)
+
+## 2. Propulsion Concepts
+
+- **Document ID:** GP-DIMENSIONS-01-001-OV-A
+- **Title:** Overview of Propulsion Concepts
+- **Link:** [GP-DIMENSIONS-01-001-OV-A.md](GP-DIMENSIONS-01-001-OV-A.md)
+
+## 3. Advanced Materials
+
+- **Document ID:** GP-DIMENSIONS-02-001-OV-A
+- **Title:** Overview of Advanced Materials
+- **Link:** [GP-DIMENSIONS-02-001-OV-A.md](GP-DIMENSIONS-02-001-OV-A.md)
+
+## 4. Novel Architectures
+
+- **Document ID:** GP-DIMENSIONS-03-001-OV-A
+- **Title:** Overview of Novel Architectures
+- **Link:** [GP-DIMENSIONS-03-001-OV-A.md](GP-DIMENSIONS-03-001-OV-A.md)
+
+## 5. Advanced AI/Consciousness
+
+- **Document ID:** GP-DIMENSIONS-04-001-OV-A
+- **Title:** Overview of Advanced AI/Consciousness
+- **Link:** [GP-DIMENSIONS-04-001-OV-A.md](GP-DIMENSIONS-04-001-OV-A.md)
+
+## 6. Socio-Economic Futures
+
+- **Document ID:** GP-DIMENSIONS-05-001-OV-A
+- **Title:** Overview of Socio-Economic Futures
+- **Link:** [GP-DIMENSIONS-05-001-OV-A.md](GP-DIMENSIONS-05-001-OV-A.md)
+
+## 7. Fundamental Physics
+
+- **Document ID:** GP-DIMENSIONS-06-001-OV-A
+- **Title:** Overview of Fundamental Physics
+- **Link:** [GP-DIMENSIONS-06-001-OV-A.md](GP-DIMENSIONS-06-001-OV-A.md)

--- a/docs/common/ds/ToC-GP-DS.md
+++ b/docs/common/ds/ToC-GP-DS.md
@@ -1,0 +1,48 @@
+# Digital Design & AI (GP-DS) - Master Index
+
+This document serves as the master index for the Digital Design & AI (GP-DS) part of the GAIA Documentation Ecosystem. It provides an organized structure and links to all relevant documents within this part.
+
+## Table of Contents
+
+1. [Digital Design Overview](#digital-design-overview)
+2. [Advanced Tools](#advanced-tools)
+3. [Cognitive UI/UX](#cognitive-uiux)
+4. [AGI Integration Concepts](#agi-integration-concepts)
+5. [Human-AI Collaboration](#human-ai-collaboration)
+6. [Knowledge Management](#knowledge-management)
+
+## 1. Digital Design Overview
+
+- **Document ID:** GP-DS-00-001-OV-A
+- **Title:** Overview of Digital Design
+- **Link:** [GP-DS-00-001-OV-A.md](GP-DS-00-001-OV-A.md)
+
+## 2. Advanced Tools
+
+- **Document ID:** GP-DS-01-001-OV-A
+- **Title:** Overview of Advanced Tools
+- **Link:** [GP-DS-01-001-OV-A.md](GP-DS-01-001-OV-A.md)
+
+## 3. Cognitive UI/UX
+
+- **Document ID:** GP-DS-02-001-OV-A
+- **Title:** Overview of Cognitive UI/UX
+- **Link:** [GP-DS-02-001-OV-A.md](GP-DS-02-001-OV-A.md)
+
+## 4. AGI Integration Concepts
+
+- **Document ID:** GP-DS-03-001-OV-A
+- **Title:** Overview of AGI Integration Concepts
+- **Link:** [GP-DS-03-001-OV-A.md](GP-DS-03-001-OV-A.md)
+
+## 5. Human-AI Collaboration
+
+- **Document ID:** GP-DS-04-001-OV-A
+- **Title:** Overview of Human-AI Collaboration
+- **Link:** [GP-DS-04-001-OV-A.md](GP-DS-04-001-OV-A.md)
+
+## 6. Knowledge Management
+
+- **Document ID:** GP-DS-05-001-OV-A
+- **Title:** Overview of Knowledge Management
+- **Link:** [GP-DS-05-001-OV-A.md](GP-DS-05-001-OV-A.md)

--- a/docs/common/fd/ToC-GP-FD.md
+++ b/docs/common/fd/ToC-GP-FD.md
@@ -1,0 +1,59 @@
+# Program Foundations (GP-FD) - Master Index
+
+This document serves as the master index for the Program Foundations (GP-FD) part of the GAIA Documentation Ecosystem. It provides an organized structure and links to all relevant documents within this part.
+
+## Table of Contents
+
+1. [Introduction & Program Vision](#introduction--program-vision)
+2. [Foundational Research](#foundational-research)
+3. [Requirements & Specification Framework](#requirements--specification-framework)
+4. [Design Framework](#design-framework)
+5. [Ethical Framework](#ethical-framework)
+6. [AI Documentation Standards](#ai-documentation-standards)
+7. [AI Foundational Topics](#ai-foundational-topics)
+
+## 1. Introduction & Program Vision
+
+- **Document ID:** GP-FD-00-000-OV-A
+- **Title:** GAIA AIR - The AI Melting Spot (Foundational Preface)
+- **Link:** [GP-FD-00-000-OV-A.md](GP-FD-00-000-OV-A.md)
+
+## 2. Foundational Research
+
+- **Document ID:** GP-FD-FRAMEWORK-00-001-OV-A
+- **Title:** GAIA AIR Integrated Framework: Doctrine, Architecture, Function, and Documentation
+- **Link:** [GP-FD-FRAMEWORK-00-001-OV-A.md](GP-FD-FRAMEWORK-00-001-OV-A.md)
+
+## 3. Requirements & Specification Framework
+
+- **Document ID:** GP-FD-05-002-SPEC-A
+- **Title:** COAFI Document IDs & INFOCODE Index
+- **Link:** [GP-FD-05-002-SPEC-A.md](GP-FD-05-002-SPEC-A.md)
+
+## 4. Design Framework
+
+- **Document ID:** GP-FD-05-003-SPEC-A
+- **Title:** COAFI Metadata Requirements
+- **Link:** [GP-FD-05-003-SPEC-A.md](GP-FD-05-003-SPEC-A.md)
+
+## 5. Ethical Framework
+
+- **Document ID:** GP-FD-04-007-OV-A
+- **Title:** Data Tectonics Navigation Strategy
+- **Link:** [GP-FD-04-007-OV-A.md](GP-FD-04-007-OV-A.md)
+
+## 6. AI Documentation Standards
+
+- **Document ID:** GP-FD-05-005-STD-A
+- **Title:** File Format Standards
+- **Link:** [GP-FD-05-005-STD-A.md](GP-FD-05-005-STD-A.md)
+
+## 7. AI Foundational Topics
+
+- **Document ID:** GP-FD-05-006-PROC-A
+- **Title:** Versioning Guidelines
+- **Link:** [GP-FD-05-006-PROC-A.md](GP-FD-05-006-PROC-A.md)
+
+- **Document ID:** GP-FD-ONTOLOGY-AMEDEO-001-SPEC-A
+- **Title:** AMEDEO Ontology Specification
+- **Link:** [GP-FD-ONTOLOGY-AMEDEO-001-SPEC-A.md](GP-FD-ONTOLOGY-AMEDEO-001-SPEC-A.md)

--- a/docs/common/gb/ToC-GP-GB.md
+++ b/docs/common/gb/ToC-GP-GB.md
@@ -1,0 +1,34 @@
+# Ground-Based Systems (GP-GB) - Master Index
+
+This document serves as the master index for the Ground-Based Systems (GP-GB) part of the GAIA Documentation Ecosystem. It provides an organized structure and links to all relevant documents within this part.
+
+## Table of Contents
+
+1. [Ground Control](#ground-control)
+2. [Ground Support Equipment (GSE)](#ground-support-equipment-gse)
+3. [Ground Transport/Logistics](#ground-transportlogistics)
+4. [Launch/Landing Facilities](#launchlanding-facilities)
+
+## 1. Ground Control
+
+- **Document ID:** GP-GB-00-001-OV-A
+- **Title:** Overview of Ground Control
+- **Link:** [GP-GB-00-001-OV-A.md](GP-GB-00-001-OV-A.md)
+
+## 2. Ground Support Equipment (GSE)
+
+- **Document ID:** GP-GB-01-001-OV-A
+- **Title:** Overview of Ground Support Equipment (GSE)
+- **Link:** [GP-GB-01-001-OV-A.md](GP-GB-01-001-OV-A.md)
+
+## 3. Ground Transport/Logistics
+
+- **Document ID:** GP-GB-02-001-OV-A
+- **Title:** Overview of Ground Transport/Logistics
+- **Link:** [GP-GB-02-001-OV-A.md](GP-GB-02-001-OV-A.md)
+
+## 4. Launch/Landing Facilities
+
+- **Document ID:** GP-GB-03-001-OV-A
+- **Title:** Overview of Launch/Landing Facilities
+- **Link:** [GP-GB-03-001-OV-A.md](GP-GB-03-001-OV-A.md)

--- a/docs/common/pm/ToC-GP-PM.md
+++ b/docs/common/pm/ToC-GP-PM.md
@@ -1,0 +1,55 @@
+# Project Management (GP-PM) - Master Index
+
+This document serves as the master index for the Project Management (GP-PM) part of the GAIA Documentation Ecosystem. It provides an organized structure and links to all relevant documents within this part.
+
+## Table of Contents
+
+1. [Planning & Execution](#planning--execution)
+2. [Configuration Management](#configuration-management)
+3. [Quality Assurance](#quality-assurance)
+4. [Risk Management](#risk-management)
+5. [Governance & Compliance](#governance--compliance)
+6. [Digital Twin ROI](#digital-twin-roi)
+7. [Go-to-Market & Field Support](#go-to-market--field-support)
+
+## 1. Planning & Execution
+
+- **Document ID:** GP-PM-00-001-OV-A
+- **Title:** Overview of Planning & Execution
+- **Link:** [GP-PM-00-001-OV-A.md](GP-PM-00-001-OV-A.md)
+
+## 2. Configuration Management
+
+- **Document ID:** GP-PM-01-001-OV-A
+- **Title:** Overview of Configuration Management
+- **Link:** [GP-PM-01-001-OV-A.md](GP-PM-01-001-OV-A.md)
+
+## 3. Quality Assurance
+
+- **Document ID:** GP-PM-02-001-OV-A
+- **Title:** Overview of Quality Assurance
+- **Link:** [GP-PM-02-001-OV-A.md](GP-PM-02-001-OV-A.md)
+
+## 4. Risk Management
+
+- **Document ID:** GP-PM-03-001-OV-A
+- **Title:** Overview of Risk Management
+- **Link:** [GP-PM-03-001-OV-A.md](GP-PM-03-001-OV-A.md)
+
+## 5. Governance & Compliance
+
+- **Document ID:** GP-PM-04-001-OV-A
+- **Title:** Overview of Governance & Compliance
+- **Link:** [GP-PM-04-001-OV-A.md](GP-PM-04-001-OV-A.md)
+
+## 6. Digital Twin ROI
+
+- **Document ID:** GP-PM-05-001-OV-A
+- **Title:** Overview of Digital Twin ROI
+- **Link:** [GP-PM-05-001-OV-A.md](GP-PM-05-001-OV-A.md)
+
+## 7. Go-to-Market & Field Support
+
+- **Document ID:** GP-PM-06-001-OV-A
+- **Title:** Overview of Go-to-Market & Field Support
+- **Link:** [GP-PM-06-001-OV-A.md](GP-PM-06-001-OV-A.md)

--- a/docs/common/rame/ToC-GP-RAME.md
+++ b/docs/common/rame/ToC-GP-RAME.md
@@ -1,0 +1,48 @@
+# Robotic Systems (GP-RAME) - Master Index
+
+This document serves as the master index for the Robotic Systems (GP-RAME) part of the GAIA Documentation Ecosystem. It provides an organized structure and links to all relevant documents within this part.
+
+## Table of Contents
+
+1. [Robotics Overview](#robotics-overview)
+2. [Assembly Systems](#assembly-systems)
+3. [Automated Inspection/QC](#automated-inspectionqc)
+4. [Robotic Maintenance](#robotic-maintenance)
+5. [Human-Robot Collaboration (HRC)](#human-robot-collaboration-hrc)
+6. [Predictive Maintenance (PdM) Integration](#predictive-maintenance-pdm-integration)
+
+## 1. Robotics Overview
+
+- **Document ID:** GP-RAME-00-001-OV-A
+- **Title:** Overview of Robotics
+- **Link:** [GP-RAME-00-001-OV-A.md](GP-RAME-00-001-OV-A.md)
+
+## 2. Assembly Systems
+
+- **Document ID:** GP-RAME-01-001-OV-A
+- **Title:** Overview of Assembly Systems
+- **Link:** [GP-RAME-01-001-OV-A.md](GP-RAME-01-001-OV-A.md)
+
+## 3. Automated Inspection/QC
+
+- **Document ID:** GP-RAME-02-001-OV-A
+- **Title:** Overview of Automated Inspection/QC
+- **Link:** [GP-RAME-02-001-OV-A.md](GP-RAME-02-001-OV-A.md)
+
+## 4. Robotic Maintenance
+
+- **Document ID:** GP-RAME-03-001-OV-A
+- **Title:** Overview of Robotic Maintenance
+- **Link:** [GP-RAME-03-001-OV-A.md](GP-RAME-03-001-OV-A.md)
+
+## 5. Human-Robot Collaboration (HRC)
+
+- **Document ID:** GP-RAME-04-001-OV-A
+- **Title:** Overview of Human-Robot Collaboration (HRC)
+- **Link:** [GP-RAME-04-001-OV-A.md](GP-RAME-04-001-OV-A.md)
+
+## 6. Predictive Maintenance (PdM) Integration
+
+- **Document ID:** GP-RAME-05-001-OV-A
+- **Title:** Overview of Predictive Maintenance (PdM) Integration
+- **Link:** [GP-RAME-05-001-OV-A.md](GP-RAME-05-001-OV-A.md)

--- a/docs/common/rs/ToC-GP-RS.md
+++ b/docs/common/rs/ToC-GP-RS.md
@@ -1,0 +1,41 @@
+# Reference Standards (GP-RS) - Master Index
+
+This document serves as the master index for the Reference Standards (GP-RS) part of the GAIA Documentation Ecosystem. It provides an organized structure and links to all relevant documents within this part.
+
+## Table of Contents
+
+1. [Standards Overview](#standards-overview)
+2. [Engineering/Design Standards](#engineeringdesign-standards)
+3. [Documentation Standards](#documentation-standards)
+4. [Test Standards](#test-standards)
+5. [Foundational Framework References](#foundational-framework-references)
+
+## 1. Standards Overview
+
+- **Document ID:** GP-RS-00-001-OV-A
+- **Title:** Overview of Standards
+- **Link:** [GP-RS-00-001-OV-A.md](GP-RS-00-001-OV-A.md)
+
+## 2. Engineering/Design Standards
+
+- **Document ID:** GP-RS-01-001-OV-A
+- **Title:** Overview of Engineering/Design Standards
+- **Link:** [GP-RS-01-001-OV-A.md](GP-RS-01-001-OV-A.md)
+
+## 3. Documentation Standards
+
+- **Document ID:** GP-RS-02-001-OV-A
+- **Title:** Overview of Documentation Standards
+- **Link:** [GP-RS-02-001-OV-A.md](GP-RS-02-001-OV-A.md)
+
+## 4. Test Standards
+
+- **Document ID:** GP-RS-03-001-OV-A
+- **Title:** Overview of Test Standards
+- **Link:** [GP-RS-03-001-OV-A.md](GP-RS-03-001-OV-A.md)
+
+## 5. Foundational Framework References
+
+- **Document ID:** GP-RS-04-001-OV-A
+- **Title:** Overview of Foundational Framework References
+- **Link:** [GP-RS-04-001-OV-A.md](GP-RS-04-001-OV-A.md)

--- a/docs/common/supl/ToC-GP-SUPL.md
+++ b/docs/common/supl/ToC-GP-SUPL.md
@@ -1,0 +1,48 @@
+# Supply Chain & Logistics (GP-SUPL) - Master Index
+
+This document serves as the master index for the Supply Chain & Logistics (GP-SUPL) part of the GAIA Documentation Ecosystem. It provides an organized structure and links to all relevant documents within this part.
+
+## Table of Contents
+
+1. [SCM Overview](#scm-overview)
+2. [Supplier Management](#supplier-management)
+3. [Ethical Sourcing](#ethical-sourcing)
+4. [Traceability](#traceability)
+5. [Logistics Optimization](#logistics-optimization)
+6. [EOL/Circular Economy](#eolcircular-economy)
+
+## 1. SCM Overview
+
+- **Document ID:** GP-SUPL-00-001-OV-A
+- **Title:** Overview of Supply Chain Management
+- **Link:** [GP-SUPL-00-001-OV-A.md](GP-SUPL-00-001-OV-A.md)
+
+## 2. Supplier Management
+
+- **Document ID:** GP-SUPL-01-001-OV-A
+- **Title:** Overview of Supplier Management
+- **Link:** [GP-SUPL-01-001-OV-A.md](GP-SUPL-01-001-OV-A.md)
+
+## 3. Ethical Sourcing
+
+- **Document ID:** GP-SUPL-02-001-OV-A
+- **Title:** Overview of Ethical Sourcing
+- **Link:** [GP-SUPL-02-001-OV-A.md](GP-SUPL-02-001-OV-A.md)
+
+## 4. Traceability
+
+- **Document ID:** GP-SUPL-03-001-OV-A
+- **Title:** Overview of Traceability
+- **Link:** [GP-SUPL-03-001-OV-A.md](GP-SUPL-03-001-OV-A.md)
+
+## 5. Logistics Optimization
+
+- **Document ID:** GP-SUPL-04-001-OV-A
+- **Title:** Overview of Logistics Optimization
+- **Link:** [GP-SUPL-04-001-OV-A.md](GP-SUPL-04-001-OV-A.md)
+
+## 6. EOL/Circular Economy
+
+- **Document ID:** GP-SUPL-05-001-OV-A
+- **Title:** Overview of EOL/Circular Economy
+- **Link:** [GP-SUPL-05-001-OV-A.md](GP-SUPL-05-001-OV-A.md)

--- a/docs/space/ss/10/index.md
+++ b/docs/space/ss/10/index.md
@@ -1,0 +1,94 @@
+# GAIA SPACE Documentation
+
+## SS 10 — Structural Systems
+
+> **Document ID:** GAIA-SPACE-SS-10-Index-IDX-A   |   **Revision:** 0.1   |   **Date:** 2025-05-05   |   **Status:** DRAFT
+
+---
+
+### Overview of SS 10 — Structural Systems
+
+This chapter provides a comprehensive overview of the structural systems of spacecraft. It covers the design, analysis, and testing of structural components and assemblies, ensuring the integrity and reliability of the spacecraft throughout its mission lifecycle.
+
+---
+
+## 1. Purpose & Scope
+
+SS 10 covers the structural systems of spacecraft, including their design, analysis, and testing. It provides detailed information on the materials, manufacturing processes, and structural configurations used in spacecraft construction.
+
+* ✔ Establishes the design principles and requirements for spacecraft structural systems.
+* ✔ Provides guidelines for the analysis and testing of structural components and assemblies.
+* ✔ Defines the materials and manufacturing processes used in spacecraft construction.
+
+---
+
+## 2. Key Sections & Their Functions
+
+The document structure follows GAIA SPACE’s modular indexing system. Each section plays a distinct role:
+
+| Section   | Title                                           | Function                                                                        |
+| --------- | ----------------------------------------------- | ------------------------------------------------------------------------------- |
+| **10-10** | Structural Design Principles                    | Overview of the design principles and requirements for spacecraft structural systems. |
+| **10-20** | Structural Analysis                             | Guidelines for the analysis of structural components and assemblies.            |
+| **10-30** | Structural Testing                              | Procedures for testing the structural integrity and reliability of spacecraft.  |
+| **10-40** | Materials and Manufacturing Processes           | Information on the materials and manufacturing processes used in spacecraft construction. |
+| **10-50** | Structural Configurations                       | Detailed descriptions of the structural configurations used in spacecraft.      |
+
+---
+
+## Document Inventory (SS 10 Files)
+
+| Document ID                                   | Title                                 | Type                       | Status |
+| --------------------------------------------- | ------------------------------------- | -------------------------- | ------ |
+| GAIA-SPACE-SS-10-00-StructuralDesign-OV-A.md  | SS 10 – Structural Design Overview    | Overview                   | DRAFT  |
+| GAIA-SPACE-SS-10-10-StructuralAnalysis-SPEC-A.yaml | Structural Analysis                  | Specification              | DRAFT  |
+| GAIA-SPACE-SS-10-20-StructuralTesting-PROC-A.md | Structural Testing                   | Procedure                  | DRAFT  |
+| GAIA-SPACE-SS-10-30-MaterialsManufacturing-SPEC-A.yaml | Materials and Manufacturing Processes | Specification              | DRAFT  |
+| GAIA-SPACE-SS-10-40-StructuralConfigurations-OV-A.md | Structural Configurations            | Overview                   | DRAFT  |
+
+---
+
+## 3. Metadata & Documentation Standards
+
+To maintain documentation integrity, GAIA SPACE employs a **structured metadata convention** ensuring interoperability across digital tools.
+
+**File-naming standard**
+`[Project]-[Domain]-[Chapter]-[Section]-[Subject]-[InfoCode]-[Variant]`
+
+Example → `GAIA-SPACE-SS-10-10-StructuralAnalysis-SPEC-A.yaml` (Structural analysis, variant A).
+
+Each file must include the **GAIA-CO-ASD-LIB metadata block** with fields for `title`, `documentID`, `revision`, `date`, `status`, `applicability`, `authors`, and so on.
+
+---
+
+## 4. AI & Automation Integration
+
+* **AI-enhanced structural analysis** for optimized design and testing.
+* **Automated regulatory updates** via NLP-driven certification tracking.
+* **Semantic search embeddings** for fast retrieval of references.
+* **Predictive maintenance analytics** aligned with mission reliability goals.
+
+---
+
+## 5. Revision Control & Future Expansions
+
+Current version **Rev 0.1 (2025-05-05)** — initial content added and document structure established.
+Pending expert review for regulatory alignment and AI index validation.
+
+---
+
+### Quick Links
+
+* **Master Index:** `../index.md`
+* **Space Domain Root:** `../`
+* **ACE Handbook (Platform-IA):** `../../ai/handbook/GAIA-PLATFORM-OF-MASTERY-v1.0.md`
+
+### Revision History
+
+| Rev | Date       | Author                | Summary                                          |
+| --- | ---------- | --------------------- | ------------------------------------------------ |
+| 0.1 | 2025-05-05 | GVECGA Assistant (o3) | Initial content added and document structure established. |
+
+---
+
+© 2025 GAIA Platforms — All Rights Reserved

--- a/docs/space/ss/20/index.md
+++ b/docs/space/ss/20/index.md
@@ -1,0 +1,94 @@
+# GAIA SPACE Documentation
+
+## SS 20 — Thermal Control Systems
+
+> **Document ID:** GAIA-SPACE-SS-20-Index-IDX-A   |   **Revision:** 0.1   |   **Date:** 2025-05-05   |   **Status:** DRAFT
+
+---
+
+### Overview of SS 20 — Thermal Control Systems
+
+This chapter provides a comprehensive overview of the thermal control systems of spacecraft. It covers the design, analysis, and testing of thermal control components and assemblies, ensuring the thermal stability and reliability of the spacecraft throughout its mission lifecycle.
+
+---
+
+## 1. Purpose & Scope
+
+SS 20 covers the thermal control systems of spacecraft, including their design, analysis, and testing. It provides detailed information on the materials, manufacturing processes, and thermal configurations used in spacecraft construction.
+
+* ✔ Establishes the design principles and requirements for spacecraft thermal control systems.
+* ✔ Provides guidelines for the analysis and testing of thermal control components and assemblies.
+* ✔ Defines the materials and manufacturing processes used in spacecraft thermal control.
+
+---
+
+## 2. Key Sections & Their Functions
+
+The document structure follows GAIA SPACE’s modular indexing system. Each section plays a distinct role:
+
+| Section   | Title                                           | Function                                                                        |
+| --------- | ----------------------------------------------- | ------------------------------------------------------------------------------- |
+| **20-10** | Thermal Design Principles                       | Overview of the design principles and requirements for spacecraft thermal control systems. |
+| **20-20** | Thermal Analysis                                | Guidelines for the analysis of thermal control components and assemblies.       |
+| **20-30** | Thermal Testing                                 | Procedures for testing the thermal stability and reliability of spacecraft.     |
+| **20-40** | Materials and Manufacturing Processes           | Information on the materials and manufacturing processes used in spacecraft thermal control. |
+| **20-50** | Thermal Configurations                          | Detailed descriptions of the thermal configurations used in spacecraft.         |
+
+---
+
+## Document Inventory (SS 20 Files)
+
+| Document ID                                   | Title                                 | Type                       | Status |
+| --------------------------------------------- | ------------------------------------- | -------------------------- | ------ |
+| GAIA-SPACE-SS-20-00-ThermalDesign-OV-A.md     | SS 20 – Thermal Design Overview       | Overview                   | DRAFT  |
+| GAIA-SPACE-SS-20-10-ThermalAnalysis-SPEC-A.yaml | Thermal Analysis                     | Specification              | DRAFT  |
+| GAIA-SPACE-SS-20-20-ThermalTesting-PROC-A.md  | Thermal Testing                      | Procedure                  | DRAFT  |
+| GAIA-SPACE-SS-20-30-MaterialsManufacturing-SPEC-A.yaml | Materials and Manufacturing Processes | Specification              | DRAFT  |
+| GAIA-SPACE-SS-20-40-ThermalConfigurations-OV-A.md | Thermal Configurations               | Overview                   | DRAFT  |
+
+---
+
+## 3. Metadata & Documentation Standards
+
+To maintain documentation integrity, GAIA SPACE employs a **structured metadata convention** ensuring interoperability across digital tools.
+
+**File-naming standard**
+`[Project]-[Domain]-[Chapter]-[Section]-[Subject]-[InfoCode]-[Variant]`
+
+Example → `GAIA-SPACE-SS-20-10-ThermalAnalysis-SPEC-A.yaml` (Thermal analysis, variant A).
+
+Each file must include the **GAIA-CO-ASD-LIB metadata block** with fields for `title`, `documentID`, `revision`, `date`, `status`, `applicability`, `authors`, and so on.
+
+---
+
+## 4. AI & Automation Integration
+
+* **AI-enhanced thermal analysis** for optimized design and testing.
+* **Automated regulatory updates** via NLP-driven certification tracking.
+* **Semantic search embeddings** for fast retrieval of references.
+* **Predictive maintenance analytics** aligned with mission reliability goals.
+
+---
+
+## 5. Revision Control & Future Expansions
+
+Current version **Rev 0.1 (2025-05-05)** — initial content added and document structure established.
+Pending expert review for regulatory alignment and AI index validation.
+
+---
+
+### Quick Links
+
+* **Master Index:** `../index.md`
+* **Space Domain Root:** `../`
+* **ACE Handbook (Platform-IA):** `../../ai/handbook/GAIA-PLATFORM-OF-MASTERY-v1.0.md`
+
+### Revision History
+
+| Rev | Date       | Author                | Summary                                          |
+| --- | ---------- | --------------------- | ------------------------------------------------ |
+| 0.1 | 2025-05-05 | GVECGA Assistant (o3) | Initial content added and document structure established. |
+
+---
+
+© 2025 GAIA Platforms — All Rights Reserved


### PR DESCRIPTION
Add steps to create directories and files for the GAIA Documentation Ecosystem in the GitHub workflow.

* **Create directories for GAIA AIR documentation:**
  - Add steps to create `docs/air` directory with subdirectories for each ATA chapter.
* **Create directories for GAIA SPACE documentation:**
  - Add steps to create `docs/space` directory with subdirectories for each SNS chapter.
* **Create directories for common parts:**
  - Add steps to create `docs/common` directory with subdirectories for each common part.
* **Create directories for GP-AM and GP-AS:**
  - Add steps to create `docs/GP-AM` directory with subdirectories for each ATA chapter.
  - Add steps to create `docs/GP-AS` directory with subdirectories for each SNS chapter.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Robbbo-T/Robbbo-T/pull/71?shareId=de93a010-eee7-43c2-9578-afe64c677fcd).

## Summary by Sourcery

Create a comprehensive documentation ecosystem for the GAIA project by establishing a structured directory system for documentation across air, space, and common domains

New Features:
- Create structured documentation directories for GAIA AIR
- Create structured documentation directories for GAIA SPACE
- Establish common documentation directories for cross-domain references

Documentation:
- Added index files for air and space documentation domains
- Created table of contents for common documentation parts like Foundations, Project Management, Digital Design, and more