### PR TITLE
Add generate document endpoint

### DIFF
--- a/COAFI/CMS-KIT/app/backend-fastapi/README.MD
+++ b/COAFI/CMS-KIT/app/backend-fastapi/README.MD
@@ -27,7 +27,8 @@ backend-fastapi/
 Los routers están organizados por dominio funcional y conectados en `main.py`. Actualmente incluye:
 
 - `users`: gestión de identidades
-- [Próximamente] `content`, `telemetry`, `audit`, `gaia-tokens`, etc.
+- `semantic-query`: búsqueda semántica, RAG y estadísticas
+- `digital-twin`: integración de gemelos digitales y sistemas de producción industrial
 
 ---
 
@@ -1060,4 +1061,23 @@ We'll identify the **best-performing parameter** from each aircraft category and
 
 | Metric               | Hybrid Baseline | AMPEL360 Q100    | Improvement |
 | -------------------- | --------------- | ---------------- | ----------- |
-| **Fuel Consumption** | 2.2 L/100km/pax | 1.43 L/100km/pax
+| **Fuel Consumption** | 2.2 L/100km/pax | 1.43 L/100km/pax | **-35%**    |
+| **CO2 Emissions**    | 98 g/pax-km     | 64 g/pax-km      | **-35%**    |
+| **NOx Emissions**    | 19.6 g/kN       | 11.4 g/kN        | **-42%**    |
+| **Cruise Speed**     | Mach 0.82       | Mach 0.95        | **+16%**    |
+| **Range**            | 6,390 km        | 7,800 km         | **+22%**    |
+| **Noise Level**      | 85.8 EPNdB      | 68.6 EPNdB       | **-20%**    |
+
+---
+
+## 🎯 Next Steps: Quantum Parameter Validation
+
+1. **CFD Modeling** – Quantum aerodynamic validation
+2. **Materials Testing** – Quantum composite prototyping
+3. **Propulsion Simulation** – Quantum interaction modeling
+4. **Systems Integration** – Agent coordination testing
+5. **Regulatory Framework** – Quantum certification standards
+
+---
+
+This parametric foundation provides the baseline for quantum enhancement, ensuring traceability and credibility in AMPEL360 BWB Q100’s revolutionary performance.

--- a/components/robbbot/MppCoafiIntegration.tsx
+++ b/components/robbbot/MppCoafiIntegration.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+
+const MppCoafiIntegration = () => {
+  const [document, setDocument] = useState(null);
+
+  const handleGenerateDocument = async () => {
+    try {
+      const response = await fetch('http://localhost:8000/generate-document', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          title: 'Technical Reference Document',
+          content: 'This is the content of the technical reference document.',
+          metadata: {
+            author: 'John Doe',
+            date: '2023-01-01',
+            version: '1.0',
+          },
+        }),
+      });
+
+      const data = await response.json();
+      setDocument(data);
+    } catch (error) {
+      console.error('Error generating document:', error);
+    }
+  };
+
+  return (
+    <div>
+      <h1>MppCoafi Integration</h1>
+      <button onClick={handleGenerateDocument}>Generate Document</button>
+      {document && (
+        <div>
+          <h2>Generated Document</h2>
+          <pre>{JSON.stringify(document, null, 2)}</pre>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MppCoafiIntegration;

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -119,6 +119,40 @@ Esta sección documenta los endpoints disponibles en la API del proyecto GAIA AI
   }
   ```
 
+### `POST /generate-document`
+
+- **Descripción**: Genera un documento de referencia técnica.
+- **Parámetros**: 
+  - `title` (requerido): Título del documento.
+  - `content` (requerido): Contenido del documento.
+  - `metadata` (opcional): Metadatos adicionales del documento.
+- **Ejemplo de Solicitud**:
+  ```bash
+  curl -X POST "https://api.gaia-air-memories.com/generate-document" -H "Content-Type: application/json" -d '{
+    "title": "Technical Reference Document",
+    "content": "This is the content of the technical reference document.",
+    "metadata": {
+      "author": "John Doe",
+      "date": "2023-01-01",
+      "version": "1.0"
+    }
+  }'
+  ```
+- **Ejemplo de Respuesta**:
+  ```json
+  {
+    "document_id": "12345",
+    "title": "Technical Reference Document",
+    "content": "This is the content of the technical reference document.",
+    "metadata": {
+      "author": "John Doe",
+      "date": "2023-01-01",
+      "version": "1.0"
+    },
+    "created_at": "2023-01-01T00:00:00Z"
+  }
+  ```
+
 ## Notas
 
 - Asegúrese de manejar adecuadamente los errores y las respuestas de la API.
@@ -1026,4 +1060,73 @@ We'll identify the **best-performing parameter** from each aircraft category and
 | **Quantum Coherence**    | Field stability monitoring      | **99.8% uptime**         | Q-Navigation Agent |
 | **Energy Recovery**      | Quantum field energy harvesting | **15% energy recovery**  | Q-Efficiency Agent |
 | **Structural Integrity** | Quantum material enhancement    | **40% weight reduction** | Q-Materials Agent  |
-| **Passenger Comfort**    | Quantum noise cancellation      | **
+| **Passenger Comfort**    | Quantum noise cancellation      | **-20 dB cabin noise**   | Q-Comfort Agent    |
+
+---
+
+## 🤖 Agent-Contextual Enhancement Strategy
+
+### Primary Quantum Agents
+
+1. **Q-Propulsion Agent**
+
+   * **Context:** Fuel efficiency
+   * **Parameters:** Thrust vectoring, combustion
+   * **Target:** 35% fuel reduction
+
+2. **Q-Aerodynamics Agent**
+
+   * **Context:** Drag reduction, lift
+   * **Parameters:** Boundary control
+   * **Target:** L/D 24:1
+
+3. **Q-Materials Agent**
+
+   * **Context:** Structural optimization
+   * **Parameters:** Quantum composites
+   * **Target:** 40% weight reduction
+
+4. **Q-Environmental Agent**
+
+   * **Context:** Emissions control
+   * **Parameters:** Molecular combustion
+   * **Target:** 42% NOx, 35% CO2 reduction
+
+### Secondary Enhancement Agents
+
+5. **Q-Navigation Agent**
+
+   * **Context:** Route optimization
+   * **Target:** 8% efficiency increase
+
+6. **Q-Maintenance Agent**
+
+   * **Context:** Predictive maintenance
+   * **Target:** 60% cost reduction
+
+---
+
+## 📈 Integrated Performance Projection
+
+| Metric               | Hybrid Baseline | AMPEL360 Q100    | Improvement |
+| -------------------- | --------------- | ---------------- | ----------- |
+| **Fuel Consumption** | 2.2 L/100km/pax | 1.43 L/100km/pax | **-35%**    |
+| **CO2 Emissions**    | 98 g/pax-km     | 64 g/pax-km      | **-35%**    |
+| **NOx Emissions**    | 19.6 g/kN       | 11.4 g/kN        | **-42%**    |
+| **Cruise Speed**     | Mach 0.82       | Mach 0.95        | **+16%**    |
+| **Range**            | 6,390 km        | 7,800 km         | **+22%**    |
+| **Noise Level**      | 85.8 EPNdB      | 68.6 EPNdB       | **-20%**    |
+
+---
+
+## 🎯 Next Steps: Quantum Parameter Validation
+
+1. **CFD Modeling** – Quantum aerodynamic validation
+2. **Materials Testing** – Quantum composite prototyping
+3. **Propulsion Simulation** – Quantum interaction modeling
+4. **Systems Integration** – Agent coordination testing
+5. **Regulatory Framework** – Quantum certification standards
+
+---
+
+This parametric foundation provides the baseline for quantum enhancement, ensuring traceability and credibility in AMPEL360 BWB Q100’s revolutionary performance.


### PR DESCRIPTION
Add new endpoint and update documentation for digital twin integration.

* **Backend Changes**
  - Add import statement for `digital_twin_router` in `main.py`.
  - Include `digital_twin_router` in `app.include_router` with prefix `/digital-twin` and tag `Digital Twin`.
  - Add new endpoint `/generate-document` using `OrchestrationBuilder` to generate technical reference documents.

* **Documentation Updates**
  - Update `README.MD` to include `digital-twin` router and new endpoint `/generate-document`.
  - Add documentation for the new endpoint `/generate-document` in `endpoints.md`.

* **Frontend Changes**
  - Add import statement for `AIInsightsWidget` in `layout.tsx`.
  - Include `AIInsightsWidget` in the sidebar widgets.

* **New Component**
  - Add `MppCoafiIntegration.tsx` with implementation example for `generate-document` command.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Robbbo-T/Robbbo-T/pull/76?shareId=38ec150d-e91e-4434-ad97-340f62786f74).

## Summary by Sourcery

Add a technical reference document generation endpoint within the digital-twin router, update documentation accordingly, and integrate the new feature into the frontend via a sidebar widget and sample component.

New Features:
- Expose a POST /generate-document endpoint under the digital-twin router
- Add MppCoafiIntegration React component to invoke the generate-document command
- Integrate AIInsightsWidget into the frontend sidebar to support insights workflows

Enhancements:
- Register digital_twin_router in the FastAPI application with the /digital-twin prefix

Documentation:
- Update README.md and endpoints.md to document the digital-twin router and the new generate-document endpoint