### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/asi-decision-diff.yml
+++ b/.github/workflows/asi-decision-diff.yml
@@ -1,5 +1,8 @@
 ---
 name: asi-decision-diff
+permissions:
+  contents: read
+  issues: write
 "on":
   pull_request:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/Robbbo-T/Robbbo-T/security/code-scanning/1](https://github.com/Robbbo-T/Robbbo-T/security/code-scanning/1)

To fix the issue, an explicit `permissions` block should be added to the workflow to limit the `GITHUB_TOKEN` permissions to the minimum required. In this workflow, only the ability to comment on pull requests is needed, which falls under the `issues: write` permission. The workflow also needs to read the repository contents (`contents: read`, which is required by `actions/checkout` and similar steps). The most concise and effective fix is to add a `permissions` block at the top workflow level (applies to all jobs) with:

```yaml
permissions:
  contents: read
  issues: write
```

This should be added immediately after the `name:` key (line 3), before the `on:` trigger. No further changes or imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Limit GITHUB_TOKEN to contents: read and issues: write by adding a permissions block to the workflow